### PR TITLE
better error trapping - fallback with no video

### DIFF
--- a/src/game/mmfile.cpp
+++ b/src/game/mmfile.cpp
@@ -398,8 +398,14 @@ mm_open_fp(mm_file *mf, FILE *file)
 
     mf->file = file;
 
+    // This is important.  If there is no file
+    // then we need to reset the audio and video
+    // pointers so that the other functions
+    // ignore the file.
     if (!mf->file) {
-        return retval;
+      mf->audio = NULL;
+      mf->video = NULL;
+      return retval;
     }
 
     ogg_sync_init(&mf->sync);

--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -911,7 +911,7 @@ LoadNewsAnim(int plr, int bw, int type, int Mode, mm_file *fp)
 
     if (AnimIndex != Index) {
         char fname[100];
-        unsigned h, w;
+        unsigned h=0, w=0;
 
         mm_close(fp);
         display::graphics.newsRect().w = 0;
@@ -938,7 +938,7 @@ LoadNewsAnim(int plr, int bw, int type, int Mode, mm_file *fp)
     MaxFrame = 0;
 
     // Specs: Display Single Frame
-    if (Mode == FIRST_FRAME) {
+    if (Mode == FIRST_FRAME && fp->video) {
         /* XXX: error checking */
         mm_decode_video(fp, display::graphics.newsOverlay());
         screen_dirty = 1;
@@ -953,8 +953,10 @@ LoadNewsAnim(int plr, int bw, int type, int Mode, mm_file *fp)
         DrawBottomNewsBox(plr);
 
         /* XXX: error checking */
-        mm_decode_video(fp, display::graphics.newsOverlay());
-        screen_dirty = 1;
+	if (fp->video) {
+	  mm_decode_video(fp, display::graphics.newsOverlay());
+	  screen_dirty = 1;
+	}
 
         /* This fade was too long given current fades impl. */
         FadeIn(2, display::graphics.palette(), 10, 0, 0); /* was: 50 */


### PR DESCRIPTION
This is a patch that does better error trapping for missing files.  It is particularly useful in situations where a file is missing as it ignores the missing file rather than overlay everything with a green screen.
