### PR TITLE
Fix leak of SDL_Surface in Surface class.

### DIFF
--- a/src/display/surface.cpp
+++ b/src/display/surface.cpp
@@ -17,6 +17,8 @@ Surface::Surface(unsigned int width, unsigned int height):
 
 Surface::~Surface()
 {
+	SDL_FreeSurface(_screen);
+	_screen = NULL;
 }
 
 SDL_Surface *Surface::surface() const


### PR DESCRIPTION
Rather embarassing leak in Surface class since I forgot to ever delete the surface.
