### PR TITLE
Add a basic testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_script:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libsdl-dev libboost-dev libpng-dev libjsoncpp-dev libogg-dev libvorbis-dev libtheora-dev
 script:
-  - mkdir build && cd build && cmake .. && make
+  - mkdir build && cd build && cmake .. && make && make test
 compiler:
   - clang
   - gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 2.8)
 project(raceintospace)
 
+enable_testing()
+
 set (raceintospace_VERSION_MAJOR 1)
 set (raceintospace_VERSION_MINOR 1)
 set (raceintospace_VERSION_RELEASE 0)

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -72,6 +72,15 @@ set(game_libraries
   jsoncpp physfs ${zlib_LIBRARY}
   )
 
+# Define one big test suite
+file(GLOB test_sources ../../test/game/*.cpp)
+add_executable(game_test ../../test/test_main.cpp ${test_sources})
+target_link_libraries(game_test ${game_libraries})
+add_test(
+  NAME game_test
+  COMMAND game_test --catch_system_error=yes
+  )
+
 # Defer to the platform-specific CMakeLists for building the actual game target
 if (APPLE)
   include(platform_macosx/platform.cmake)

--- a/test/game/dummy_test.cpp
+++ b/test/game/dummy_test.cpp
@@ -1,0 +1,7 @@
+#define BOOST_TEST_MODULE Dummy
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(dummy_test)
+{
+    BOOST_CHECK(2 + 2 == 4);
+}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,4 @@
+// This file generates a main() function for the game_test target
+// See:
+//  http://www.boost.org/doc/libs/1_52_0/libs/test/doc/html/utf/user-guide/usage-variants/single-header-variant.html
+#include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
This wires up [Boost Test](http://www.boost.org/doc/libs/1_52_0/libs/test/doc/html/) into the build system such that we can define test cases in `test/game/*.cpp` and execute them via `make test`.
