### PR TITLE
Move Windows audio driver selection to Windows platform file

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -39,13 +39,6 @@ void Graphics::create(const std::string &title, bool fullscreen)
         throw std::runtime_error(SDL_GetError());
     }
 
-
-    //TODO: Move this to a separate audio object
-    if (!SDL_getenv("SDL_AUDIODRIVER")) {
-//        INFO1("fixing WIN32 audio driver setup");
-        SDL_putenv("SDL_AUDIODRIVER=waveout");
-    }
-
     if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) {
         throw std::runtime_error(SDL_GetError());
     }

--- a/src/game/platform_windows/main.c
+++ b/src/game/platform_windows/main.c
@@ -1,6 +1,10 @@
 int game_main(int argc, char *argv[]);
 
-int main(int argc, char ** argv)
+int main(int argc, char **argv)
 {
-	return game_main(argc, argv);
+    if (!SDL_getenv("SDL_AUDIODRIVER")) {
+        SDL_putenv("SDL_AUDIODRIVER=waveout");
+    }
+
+    return game_main(argc, argv);
 }


### PR DESCRIPTION
`SDL_AUDIODRIVER=waveout` is valid only on Win32, according to:
   http://www.libsdl.org/docs/html/sdlenvvars.html

A cursory examination of `SDL_putenv()` suggests that it is safe to invoke in this context, even before SDL has been initialized. Therefore, we can set the audio device in the platform-specific main() implementation.
