### PR TITLE
Alternative platform pull-up

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -51,6 +51,8 @@
 #include "endianness.h"
 #include "filesystem.h"
 
+#include <ctype.h>
+
 #define MODEM_ERROR 4
 #define NOTSAME 2
 #define SAME_ABORT 0

--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -8,6 +8,10 @@
 #include "display/surface.h"
 #include "display/image.h"
 
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
 /** Print string at specific position
  *
  * The function will print a string at a certain position.

--- a/src/game/fs.cpp
+++ b/src/game/fs.cpp
@@ -30,6 +30,7 @@
 #include <assert.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <ctype.h>
 
 /** path separator setup */
 #ifndef PATHSEP

--- a/src/game/pace.cpp
+++ b/src/game/pace.cpp
@@ -11,6 +11,8 @@
 #include "gr.h"
 #include "mmfile.h"
 
+#include <ctype.h>
+
 void randomize(void);
 void SMove(void *p, int x, int y);
 void LMove(void *p);

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -39,6 +39,8 @@
 #include "pace.h"
 #include "filesystem.h"
 
+#include <ctype.h>
+
 void DrawPrefs(int where, char a1, char a2);
 void HModel(char mode, char tx);
 void Levels(char plr, char which, char x);

--- a/src/game/randomize.cpp
+++ b/src/game/randomize.cpp
@@ -45,6 +45,8 @@ RD cost is loosly based in the basic model
 #include "sdlhelper.h"
 #include "display/graphics.h"
 
+#include <ctype.h>
+
 /*random_number divides the randomization in 2,
  so there is a lower chance of getting an extreme */
 /*random_min is used to give more chances of getting a 1 */

--- a/src/game/roster.cpp
+++ b/src/game/roster.cpp
@@ -4,9 +4,8 @@
 #include <boost/foreach.hpp>
 
 #include <fstream>
-
+#include <stdlib.h>
 #include "roster.h"
-
 #include "fs.h"
 
 Roster::Roster(std::istream &input_stream)

--- a/src/game/roster_entry.cpp
+++ b/src/game/roster_entry.cpp
@@ -2,6 +2,7 @@
 #include "roster_group.h"
 
 #include <assert.h>
+#include <string.h>
 
 #include "options.h"
 #include "pace.h"


### PR DESCRIPTION
Adding some necessary headers to be able to compile on an undisclosed platform.  This platform appears to use much stricter settings.  (Edit: The specification for &lt;cstring&gt; (for example) only mandates that this pull the methods in to the std:: namespace.  Pulling them in to the global namespace is optional.  &lt;string.h&gt; will always have the global level method, so here we are...)

It's not complete, but it's a start for now.  I've tested it under Windows, the change is harmless there.
