### PR TITLE
Fixed wrong duration when cycling future missions

### DIFF
--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -1550,7 +1550,7 @@ void Missions(char plr, int X, int Y, int val, char bub)
         display::graphics.setForegroundColor(5);
 
         if (V[val].E > 0) {
-            if (F5 > V[val].E && Mis.Dur == 1) {
+            if (F5 > V[val].E && V[val].Z == 1) {
                 DurPri(F5);
             } else {
                 DurPri(V[val].E);


### PR DESCRIPTION
When we lock the filter for a desired duration and click
next/prev, at the first time the default mission
duration was displayed instead of the locked one.

The reason was because it was checked if the mission is of duration type against the `Mis` structure. But at that point in the code that structure is still filled with data for the _previous_ mission (before we clicked next/prev).