### PR TITLE
Update PhysicsFS to 3.0.1

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -121,11 +121,8 @@ endif (BUILD_JSONCPP)
 ###
 # PhysicsFS
 
-# I want 2.1 features, even if they're not out yet, so I made my own tarball
-#set (physfs_Version 2.0.3)
-#set (physfs_URL http://icculus.org/physfs/downloads/physfs-${physfs_Version}.tar.bz2)
-set (physfs_Version 2.1.0-pre20121013)
-set (physfs_URL https://s3.amazonaws.com/willglynn/physfs-${physfs_Version}.tgz)
+set (physfs_Version 3.0.1)
+set (physfs_URL http://icculus.org/physfs/downloads/physfs-${physfs_Version}.tar.bz2)
 set (physfs_Dir ${CMAKE_CURRENT_BINARY_DIR}/physfs-${physfs_Version})
 
 # physfs 2.0.3 complains about FSPathMakeRef et al being deprecated, and warnings are treated as errors


### PR DESCRIPTION
The project used an unofficial 2.1 version of PhysicsFS. A couple of months ago, a new PhysicsFS version has finally been released. Moreover, the old 2.1 version prevented compilation of raceintospace on GCC 6 due to [misleading indentation](https://gcc.gnu.org/gcc-6/porting_to.html#Wmisleading-indentation). The 3.0.1 version seems to compile and run just fine, so it would be good to update.

Unfortunately, this commit is not properly tested, but the PhysicsFS release is [claimed to be source and binary compatible](https://icculus.org/pipermail/physfs/2017-September/001247.html).