### PR TITLE
Fix physfs warnings on 18.04 ubuntu

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -120,15 +120,11 @@ endif (BUILD_JSONCPP)
 
 ###
 # PhysicsFS
-
-# I want 2.1 features, even if they're not out yet, so I made my own tarball
-#set (physfs_Version 2.0.3)
-#set (physfs_URL http://icculus.org/physfs/downloads/physfs-${physfs_Version}.tar.bz2)
-set (physfs_Version 2.1.0-pre20121013)
-set (physfs_URL https://s3.amazonaws.com/willglynn/physfs-${physfs_Version}.tgz)
+set (physfs_Version 3.0.1)
+set (physfs_URL https://icculus.org/physfs/downloads/physfs-${physfs_Version}.tar.bz2)
 set (physfs_Dir ${CMAKE_CURRENT_BINARY_DIR}/physfs-${physfs_Version})
 
-# physfs 2.0.3 complains about FSPathMakeRef et al being deprecated, and warnings are treated as errors
+# physfs complains about FSPathMakeRef et al being deprecated, and warnings are treated as errors
 # Turn it back into a warning instead
 if (APPLE)
   set (physfs_Flags -Wno-error=deprecated-declarations)


### PR DESCRIPTION
@peyre can you test this branch out (just see if it compiles for you)? I needed this change to get the build working on one of my newer linux machines (18.04 Ubuntu). It also removes a reliance on a s3 hosted file which may not be around forever. 