### PR TITLE
Fix intel images

### DIFF
--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -1186,8 +1186,11 @@ void HarIntel(char p, char acc)
     SaveIntel(p, prg, ind);
 }
 
+/* Clears the Intel image area and draws the intel background layer.
+ */
 void DrawIntelBackground()
 {
+    fill_rectangle(153, 32, 310, 131, 0);
     boost::shared_ptr<display::PalettizedSurface> background(Filesystem::readImage("images/intel_background.png"));
     background->exportPalette();
     display::graphics.screen()->draw(background, 153, 32);

--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -1190,6 +1190,16 @@ void DrawIntelBackground()
     display::graphics.screen()->draw(background, 153, 32);
 }
 
+/* Draws the image for an Intelligence Briefing.
+ *
+ * Because program indices begin at 0, and png image files are indexed
+ * starting at 1 (intel.but.0.png was the intel background) the values
+ * do not correspond. This is handled by the function internally.
+ * The program/mission offset should be used.
+ *
+ * \param plr Player side (0 for US, 1 for USSR)
+ * \param poff Program/Mission index
+ */
 void DrawIntelImage(char plr, char poff)
 {
     DrawIntelBackground();
@@ -1207,7 +1217,10 @@ void DrawIntelImage(char plr, char poff)
     assert(poff > 0 && poff <= 69);
 
     char filename[128];
-    snprintf(filename, sizeof(filename), "images/intel.but.%d.png", (int)poff);
+    snprintf(filename,
+             sizeof(filename),
+             "images/intel.but.%d.png",
+             (int)poff + 1);
     boost::shared_ptr<display::PalettizedSurface> image(Filesystem::readImage(filename));
 
     display::graphics.screen()->draw(image, 153, 32);

--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -1207,17 +1207,13 @@ void DrawIntelImage(char plr, char poff)
 {
     DrawIntelBackground();
 
-    if (poff == 0) {
-        return;
-    }
-
     if (poff < 56) {
         if (plr == 1) {
             poff = poff + 28;
         }
     }
 
-    assert(poff > 0 && poff <= 69);
+    assert(poff >= 0 && poff <= 68);
 
     char filename[128];
     snprintf(filename,


### PR DESCRIPTION
The internal index used for tracking Intelligence briefings starts at zero while the external image files started at one. This loaded incorrect images and produced situations where files could not be found, causing the game to crash. This change aligns the indexing, and tries to catch errors if an Intel image file cannot be loaded.