### PR TITLE
Fix array overflow error

### DIFF
--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -48,8 +48,7 @@ struct MisEval Mev[60];  // was *Mev;
 struct mStr Mis;
 REPLAY Rep;
 
-char pCnt, tMen;    // Counter for pAry
-int pAry[15]; // Array for Presige Firsts compelted
+char tMen;
 
 char MANNED[2];
 char CAP[2];
@@ -117,8 +116,6 @@ int Launch(char plr, char mis)
     int i, j, t, k, mcode, avg, temp = 0;
     char total;
     STEP = FINAL = JOINT = PastBANG = 0;
-    memset(pAry, 0x00, sizeof pAry);
-    pCnt = 0; // reset values
     MisStat = tMen = 0x00; // clear mission status flags
 
     remove_savedat("REPLAY.TMP");  // make sure replay buffer isn't there

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -52,9 +52,8 @@ char InSpace;
 char Dock_Skip; /**< used for mission branching */
 
 extern uint16_t MisStat;
-extern char pCnt, tMen;          // Counter for pAry
+extern char tMen;
 extern bool fullscreenMissionPlayback;
-extern int pAry[15];         /**< Array for Presige Firsts compelted */
 
 void Tick(char);
 
@@ -520,10 +519,6 @@ void MisCheck(char plr, char mpad)
 
         if (STEP > 30 || STEP < 0) {
             delay(20);
-        }
-
-        if (Mev[STEP].Prest != 0) {
-            pAry[pCnt++] = STEP;
         }
 
         if (Mev[STEP].sgoto == Mev[STEP].fgoto && Mev[STEP].trace != 0x7f) {


### PR DESCRIPTION
Removes an array responsible for an overflow error. The array is
intended to track which mission steps had prestige firsts, but is too
short for its purpose. It overflows, and other variables are
overwritten. The array is never referenced after assignment, so it is
removed rather than lengthened.

This resolves #200