### PR TITLE
Fix viewstand news

### DIFF
--- a/src/game/budget.cpp
+++ b/src/game/budget.cpp
@@ -698,7 +698,9 @@ int RetFile(char plr, int card)
     int bline, i;
 
     oldNews = &interimData.tempEvents[card + plr * 42];
-    sprintf(buffer, "%s", interimData.eventBuffer + oldNews->offset);
+    // sprintf(buffer, "%s", interimData.eventBuffer + oldNews->offset);
+    memcpy(buffer, interimData.eventBuffer + oldNews->offset, oldNews->size);
+    buffer[oldNews->size] = '\0';
 
     bline = 0;
 


### PR DESCRIPTION
Fixes bugs in how news events are recorded and displayed. This corrects an overrun issue in the viewing stand that caused multiple news broadcasts to be displayed at the same time. It also loads the previously recorded news broadcast when loading into a turn (rather than right before the turn), as with an autosave, instead of recreating the broadcast & event resolution. This should resolve issue #204.