### PR TITLE
Skip start-of-turn maintenance if loading autosave

### DIFF
--- a/doc/manual/manual.md
+++ b/doc/manual/manual.md
@@ -338,7 +338,7 @@ Here you can get secret intelligence on your opponent, starting in Fall 1958.  O
 
 **Library**
 
-This is where to go for intelligence briefings.  Each turn you’ll receive a report that your opponent is developing a given component or is preparing a given mission.  Again, this may not be accurate.
+This is where to go for intelligence briefings.  Each fall you’ll receive a report that your opponent is developing a given component or is preparing a given mission.  Again, this may not be accurate.
 
 **CIA/KGB Statistics**
 


### PR DESCRIPTION
Checks if a save is an autosave before performing pre-turn actions. The
autosave is created at the end of a player's turn, and records the game
state to that point. This is the same phenomenon as in issue #204 fixed
by commit 075799eb06031a2b8804533d448b2f885705c067. This stops the game
from incorrectly
* generating extra Intel briefings, threatening an array overrun
* resetting R&D mods for the turn
* changing budget records/estimates
* changing the budget expenditure records
* performing duplicate presidential reviews