### PR TITLE
Fix error disabling VAB buttons

### DIFF
--- a/src/game/vab.cpp
+++ b/src/game/vab.cpp
@@ -1114,7 +1114,7 @@ void VAB(char plr)
             key = 0;
             GetMouse();
 
-            if (mousebuttons > 0 || key > 0) {
+            if (mousebuttons <= 0 && key <= 0) {
                 continue;
             }
 


### PR DESCRIPTION
Corrects a control loop bug where all valid VAB input was being skipped.

Resolves issue #228.