### PR TITLE
Very basic support for tarball creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,3 +20,11 @@ add_subdirectory(lib)
 add_subdirectory(src)
 install(PROGRAMS icons/raceintospace.desktop DESTINATION /usr/share/applications)
 install(FILES icons/raceintospace.xpm DESTINATION /usr/share/pixmaps)
+
+set(PROJECT_VERSION "${raceintospace_VERSION_MAJOR}.${raceintospace_VERSION_MINOR}.${raceintospace_VERSION_RELEASE}")
+execute_process(COMMAND git rev-list -1 --abbrev-commit HEAD
+                OUTPUT_VARIABLE COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(ARCHIVE_NAME "${CMAKE_PROJECT_NAME}-${PROJECT_VERSION}-git${COMMIT}")
+add_custom_target(dist
+    COMMAND git archive --prefix="${ARCHIVE_NAME}/" HEAD | bzip2 > "${CMAKE_BINARY_DIR}/${ARCHIVE_NAME}.tar.bz2"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Basic support for creation of source tarball. Useful for creation of binary package.

Is there some reason no release or tag is on github? Version in project is 1.1, but no release was ever done here. Could be some release made?