### PR TITLE
Fix bug with assigning joint missions on Pad B

### DIFF
--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -171,7 +171,7 @@ bool SaturnInRange(unsigned int year, unsigned int season)
  */
 bool JointMissionOK(char plr, char pad)
 {
-    return (pad >= 0 && pad < MAX_LAUNCHPADS - 2) &&
+    return (pad >= 0 && pad < MAX_LAUNCHPADS - 1) &&
            (Data->P[plr].LaunchFacility[pad + 1] == 1) &&
            ((Data->P[plr].Future[pad + 1].MissionCode == Mission_None) ||
             (Data->P[plr].Future[pad + 1].part == 1));


### PR DESCRIPTION
Fixes issue #238 preventing joint missions from being scheduled on
launch pad B. An off-by-one error was introduced in commit
6eddedbbf7f93a02d63d1b894ade8e84f2a9a13e.