### PR TITLE
Update flight pool after 'naut killed by news

### DIFF
--- a/src/game/news_suq.cpp
+++ b/src/game/news_suq.cpp
@@ -785,6 +785,7 @@ char REvent(char plr)
         Data->P[plr].Pool[i].Status = AST_ST_DEAD;
         Data->P[plr].MissionCatastrophicFailureOnTurn = 2;
         xMODE |= xMODE_SPOT_ANIM; //trigger spot anim
+        Replace_Snaut(plr);
 
         //cancel manned missions
         for (size_t pad = 0; pad < MAX_LAUNCHPADS; pad++) {


### PR DESCRIPTION
Fixes an issue where one of the news event kills an astro/cosmonaut but
fails to update the flight pools; the naut would be simultaneously dead
and assigned to a flight crew.