### PR TITLE
Correct music for mission control, launch pad

### DIFF
--- a/src/game/radar.cpp
+++ b/src/game/radar.cpp
@@ -583,7 +583,7 @@ void PadPict(char poff)
 void ShowPad(char plr, char pad)
 {
     char temp;
-    music_start((plr == 1) ? M_USMIL : M_USSRMIL);
+    music_start((plr == 0) ? M_USMIL : M_USSRMIL);
     PadDraw(plr, pad);
     temp = CheckCrewOK(plr, pad);
 

--- a/src/game/rush.cpp
+++ b/src/game/rush.cpp
@@ -318,7 +318,7 @@ void Rush(char plr)
     pRush = (Data->P[plr].Cash >= 3) ? 1 : 0;
     fCsh = Data->P[plr].Cash;
     display::graphics.setForegroundColor(1);
-    music_start((plr == 1) ? M_USMIL : M_USSRMIL);
+    music_start((plr == 0) ? M_USMIL : M_USSRMIL);
     FadeIn(2, 10, 0, 0);
     WaitForMouseUp();
 


### PR DESCRIPTION
Switches the music used in the Mission Control building and Launch Pad
view so the US uses the USMIL and the USSR uses the USSRMIL music
tracks.