### PR TITLE
Check if PhysicsFS was initialized before deinit

### DIFF
--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -38,7 +38,11 @@ Filesystem::~Filesystem()
 {
     // shut. down. everything.
     // this can fail, but whatever
-    PHYSFS_deinit();
+    // Wrap this in a safety check because it causes errors if called
+    // before initialization.
+    if (PHYSFS_isInit()) {
+        PHYSFS_deinit();
+    }
 }
 
 void Filesystem::init(const char *argv0)


### PR DESCRIPTION
Avoid engaging in PhysicsFS cleanup unless initialization occurred.
Initialization takes place in the game's game_main_impl, which is not
encountered during testing.