### PR TITLE
Prevent mission duration penalties from doubling

### DIFF
--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -278,11 +278,21 @@ int Launch(char plr, char mis)
         MisPrt();
     }
 
-    MisDur(plr, Data->P[plr].Mission[mis].Duration);
+    // MisSkip is based on PrestMin, which calculates penalties for both
+    // prestige goals _and_ duration penalties. Consequently, having a
+    // distinct MisDur function to add duration penalties results in
+    // a double penalty problem. I believe this to be the result of
+    // old code, where skipped prestige steps (MisSkip) were applied
+    // separately of duration penalties (MisDur). However, at some
+    // point the method of computing prestige penalties, PrestMin(),
+    // got used for both. However, the history of this lies back beyond
+    // the First Commit -- rnyoakum
+    MisSkip(plr, Find_MaxGoal());
+    // MisDur(plr, Data->P[plr].Mission[mis].Duration);
 
-    if (MANNED[0] > 0 || MANNED[1] > 0 || mcode == 1 || mcode == 7 || mcode == 8) {
-        MisSkip(plr, Find_MaxGoal());
-    }
+    // if (MANNED[0] > 0 || MANNED[1] > 0 || mcode == 1 || mcode == 7 || mcode == 8) {
+    //     MisSkip(plr, Find_MaxGoal());
+    // }
 
     MisRush(plr, Data->P[plr].Mission[mis].Rushing);
     STEPnum = 0;

--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -883,8 +883,12 @@ void MissionSetDown(char plr, char mis)
 /**
  * Apply duration penalty to mission steps in manned missions.
  *
+ * TODO: This functionality appears to have been appropriated by
+ * MisSkip, via PrestMin(). This needs to be verified, and if so, it
+ * should be removed completely.
+ *
  * \param plr current player
- * \param dur mission duration in days
+ * \param dur mission duration in duration level (A-F).
  */
 void
 MisDur(char plr, char dur)
@@ -934,6 +938,10 @@ MisDur(char plr, char dur)
 
 /**
  * Compute and apply safety penalties to mission steps.
+ *
+ * TODO: This takes a parameter ms, used originally to determine the
+ * maximum prestige requirement of the mission. However, it's no
+ * longer used, and should be removed.
  *
  * \param plr current player
  */


### PR DESCRIPTION
Fixes a rare issue where a mission duration penalty of 15 or more would
be applied twice to the mission. Missions have duration penalties
applied by MisDur() and prestige penalties applied by MisSkip(). At some
point, MisSkip() started calculating both the duration and prestige
penalties, leading to a double-duration bug. MisDur() was disabled to
stop this, but only for penalties on two skipped durations or less. This
disabled MisDur() entirely, relying solely on MisSkip for
prestige/duration penalties.