### PR TITLE
Compile game sources with test code

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -85,16 +85,6 @@ set(game_libraries
   raceintospace_protobuf
   )
 
-# Define one big test suite
-file(GLOB test_sources ../../test/game/*.cpp)
-add_executable(game_test ../../test/test_main.cpp ${test_sources})
-set_target_properties(game_test PROPERTIES COMPILE_FLAGS "-DBOOST_TEST_NO_LIB=1")
-target_link_libraries(game_test ${game_libraries})
-add_test(
-  NAME game_test
-  COMMAND game_test --catch_system_error=yes
-  )
-
 # Defer to the platform-specific CMakeLists for building the actual game target
 if (APPLE)
   include(platform_macosx/platform.cmake)
@@ -103,3 +93,21 @@ elseif (WINDOWS)
 else()
   include(platform_misc/platform.cmake)
 endif()
+
+# Run this after the platform includes so ${game_sources} will be
+# populated with platform-specific files.
+# Not using (file GLOB ...) because CMake documentation recommends
+# against it (https://cmake.org/cmake/help/v3.14/command/file.html)
+set(test_dir ${PROJECT_SOURCE_DIR}/test)
+set(test_sources
+  ${test_dir}/game/dummy_test.cpp
+  ${test_dir}/game/roster_test.cpp
+  )
+
+add_executable(game_test ../../test/test_main.cpp ${test_sources} ${game_sources})
+set_target_properties(game_test PROPERTIES COMPILE_FLAGS "-DBOOST_TEST_NO_LIB=1")
+target_link_libraries(game_test ${game_libraries})
+add_test(
+  NAME game_test
+  COMMAND game_test --catch_system_errors=yes
+  )

--- a/src/game/platform_macosx/platform.cmake
+++ b/src/game/platform_macosx/platform.cmake
@@ -32,10 +32,13 @@ endforeach(datafile)
 # Build the .app in the CMake build root
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}")
 
+# Add the platform-specific source files needed for testing
+list(APPEND game_sources platform_macosc/music_osx.cpp)
+
 set(app "Race Into Space")
 
 add_executable("${app}" MACOSX_BUNDLE
-  platform_macosx/SDLMain.m platform_macosx/music_osx.cpp
+  platform_macosx/SDLMain.m
   ${game_sources}
   ${BundleResources}
   )

--- a/src/game/platform_misc/platform.cmake
+++ b/src/game/platform_misc/platform.cmake
@@ -2,14 +2,16 @@
 # until after we started the build process.
 add_definitions(-DHAVE_SDL_GETENV)
 
-# Make sure we can fine fake_unistd.h
+# Make sure we can find fake_unistd.h
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/platform_misc)
+
+# Add the platform-specific source files needed for testing
+list(APPEND game_sources music_vorbis.cpp)
 
 set(app "raceintospace")
 
 add_executable(${app}
   ${game_sources}
-  music_vorbis.cpp
   platform_misc/main.c
   )
 
@@ -20,5 +22,3 @@ install(TARGETS raceintospace DESTINATION bin)
 
 file(GLOB data_dirs "${PROJECT_SOURCE_DIR}/data/*")
 install(DIRECTORY ${data_dirs} DESTINATION share/raceintospace) 
-
-

--- a/src/game/platform_windows/platform.cmake
+++ b/src/game/platform_windows/platform.cmake
@@ -6,14 +6,16 @@ add_definitions(-DCONFIG_WIN32)
 # until after we started the build process.
 add_definitions(-DHAVE_SDL_GETENV)
 
-# Make sure we can fine fake_unistd.h
+# Make sure we can find fake_unistd.h
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/platform_windows)
+
+# Add the platform-specific source files needed for testing
+list(APPEND game_sources music_vorbis.cpp)
 
 set(app "Race Into Space")
 
 add_executable(${app}
   ${game_sources}
-  music_vorbis.cpp
   platform_windows/dirent.c
   platform_windows/main.c
   )

--- a/test/game/dummy_test.cpp
+++ b/test/game/dummy_test.cpp
@@ -1,7 +1,10 @@
-#define BOOST_TEST_MODULE Dummy
 #include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(dummy_suite)
 
 BOOST_AUTO_TEST_CASE(dummy_test)
 {
     BOOST_CHECK(2 + 2 == 4);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/game/roster_test.cpp
+++ b/test/game/roster_test.cpp
@@ -1,0 +1,22 @@
+#include <boost/test/unit_test.hpp>
+
+#include "game/roster.h"
+#include "game/roster_group.h"
+#include "game/roster_entry.h"
+
+
+BOOST_AUTO_TEST_SUITE(roster_suite)
+
+BOOST_AUTO_TEST_CASE(roster_test)
+{
+    BOOST_CHECK(2 + 2 == 4);
+}
+
+// BOOST_AUTO_TEST_CASE(TestLoadRoster)
+// {
+//     // Roster roster = Roster::load("test_roster.json");
+//     BOOST_CHECK( true );
+//     // BOOST_CHECK(roster.getGroup(0, 1));
+// }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,4 +1,5 @@
 // This file generates a main() function for the game_test target
 // See:
 //  http://www.boost.org/doc/libs/1_52_0/libs/test/doc/html/utf/user-guide/usage-variants/single-header-variant.html
+#define BOOST_TEST_MODULE RaceIntoSpaceTest
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
Compiles the game source code along with the test code so Boost tests
will be able to reference and call the game source. This is needed so it
may be tested.