### PR TITLE
Reflect duration changes in FM mission penalty

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -939,10 +939,12 @@ MisDur(char plr, char dur)
 /**
  * Compute and apply safety penalties to mission steps.
  *
+ *
  * TODO: This takes a parameter ms, used originally to determine the
  * maximum prestige requirement of the mission. However, it's no
  * longer used, and should be removed.
  *
+ * \note  This assumes the global variable Mis is correctly filled.
  * \param plr current player
  */
 void
@@ -950,7 +952,7 @@ MisSkip(char plr, char ms)
 {
     int i, j, diff;
 
-    diff = PrestMin(plr);
+    diff = PrestMin(plr, Mis);
 
     diff = MAX(diff, 0);
 

--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -173,26 +173,25 @@ PrestMap(int val)
  *  - Duration A-F, because there's already a category for that, and
  *  - Woman In Space, because it's not a technological challenge.
  *
- * This function relies upon the global variable Mis.
  *
- * \param plr current player (0 for USA, 1 for USSR)
- * \return penalty
- *
- * \note Call only when Mis is valid
+ * \note  Call only if mission has correct Index, PCat, and Days fields.
+ * \param plr  current player (0 for USA, 1 for USSR)
+ * \param mission  the mission to evaluate
+ * \return  sum of prestige, duration, and new mission penalties.
  */
-char PrestMin(char plr)
+char PrestMin(char plr, const struct mStr &mission)
 {
     int maxMilestone = 0, Neg = 0;
     bool newMilestone = false;
 
-    if (Mis.Index == 0) {
+    if (mission.Index == 0) {
         return 0;
     }
 
     // Find the maximum milestone & determine if mission offers a new
     // milestone
     for (int i = 0; i < 5; i++) {
-        int milestone = PrestMap(Mis.PCat[i]);
+        int milestone = PrestMap(mission.PCat[i]);
         maxMilestone = MAX(maxMilestone, milestone);
         newMilestone = newMilestone ||
                        (milestone >= 0 && Data->Mile[plr][milestone] == 0);
@@ -206,7 +205,7 @@ char PrestMin(char plr)
         }
     }
 
-    int reqDuration = MAX(Mis.Days  - 1, 0);
+    int reqDuration = MAX(mission.Days  - 1, 0);
     int playerDuration = MAX(Data->P[plr].DurationLevel, 0);
 
     // If mission.hasMilestone(Milestone_LunarPass)...

--- a/src/game/prest.h
+++ b/src/game/prest.h
@@ -3,7 +3,7 @@
 
 int PrestNeg(char plr, int i);
 char Set_Goal(char plr, char which, char control);
-char PrestMin(char plr);
+char PrestMin(char plr, const struct mStr &mission);
 int Find_MaxGoal(void);
 int U_AllotPrest(char plr, char mis);
 int AllotPrest(char plr, char mis);


### PR DESCRIPTION
Updates the mission penalty display in Future Missions to reflect the
current state of the navigation bar. The "Duration Pie" display used for
navigation doubles as the duration setting for variable-length missions,
such as Manned Orbital Duration. When a duration mission is selected,
the mission's duration text and penalty will update each time the
Duration setting changes to accurately reflect the current mission
setup. Fixes issue #246 and implements issue #256.