### PR TITLE
Fix crash on News Event card

### DIFF
--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -1065,7 +1065,7 @@ ShowEvt(char plr, char crd)
     boost::shared_ptr<display::PalettizedSurface> image;
 
     try {
-        Filesystem::readImage(filename);
+        image = Filesystem::readImage(filename);
     } catch (const std::runtime_error &err) {
         CERROR4(filesys, "error loading %s: %s", filename, err.what());
         return;


### PR DESCRIPTION
Stop the News event image from causing a crash. This bug was introduced
in commit #310 (00e491b9c67c0520e708baae1d27200583301f02).