### PR TITLE
Fix Titan Tech transfer for multiple programs

### DIFF
--- a/src/game/rdplex.cpp
+++ b/src/game/rdplex.cpp
@@ -1525,12 +1525,12 @@ BuyUnit(char category, char unit, char player_index)
             //old code: Data->P[player_index].Rocket[ROCKET_HW_TWO_STAGE].Safety = 40;
             Data->P[player_index].Rocket[ROCKET_HW_TWO_STAGE].Safety = 10 + tt;
 
-            if ((n1 >= 75 || n5 >= 75) && (n3 >= 75 || n4 >= 75))  // Tech from multiple programs
-                //old code: Data->P[player_index].Rocket[ROCKET_HW_TWO_STAGE].Safety = 65;
-
-            {
-                break;
+            // Tech from multiple programs
+            if ((n1 >= 75 || n5 >= 75) && (n3 >= 75 || n4 >= 75)) {
+                Data->P[player_index].Rocket[ROCKET_HW_TWO_STAGE].Safety = 65;
             }
+
+            break;
 
         case ROCKET_HW_THREE_STAGE:    // Saturn/N1
             if (n1 > 10) {


### PR DESCRIPTION
Restores disabled technology transfer when purchasing the two-stage
rocket when the One-stage/Boosters and Three-stage/Mega are above 75%.
Having one of each was not giving any bonus beyond the best of either.
Also, the bug could cause purchase of the Two-stage rocket to run into
the technology transfer code for the Three-stage rocket.