### PR TITLE
Feature disable packing

### DIFF
--- a/src/game/Buzz_inc.h
+++ b/src/game/Buzz_inc.h
@@ -48,19 +48,29 @@ extern "C" {
 #include "proto.h"    // prototypes and general defines
 #include "music.h"    // defines for music names
 
-/* FIXME: non-portable. Used to get struct layout like in DOS days */
-#pragma pack( 1 )
+/* Originally, the code relied upon tight struct packing, because
+ * file data was read directly into the memory space of data structures.
+ * An open-ended pragma was used to enforce tight packing. However,
+ * this created several problems:
+ *   - It caused problems in gamedata.h
+ *   - Header files with structs/classes defined could be interpreted
+ *   differently by code in multiple files, with one section of code
+ *   treating the struct as packed and another as unpacked
+ *   - It locks the structs/classes so they cannot be modified, which
+ *   is inconvenient for major data types.
+ *   - It dictated include ordering.
+ *
+ * If restoring tight packing, define ALTERED_STRUCTURE_PACKING as
+ * some files - gamedata.h - do not like the tight packing and check
+ * for ALTERED_STRUCTURE_PACKING to see if it is enabled.
+ */
+// #pragma pack( 1 )
 
 #include "data.h"     // main data structures
 
 /* get the alignment back to defaults */
 /* #pragma pack() */
-
-/* BIG FIXME: Unfortunately structures defined in some functions rely on tight
- * packing. This setting mainly breaks things in gamedata.h, so we make sure
- * we notice bad order of #includes. That's another good reason to make all
- * code use the gamedata.c interfaces. */
-#define ALTERED_STRUCTURE_PACKING
+// #define ALTERED_STRUCTURE_PACKING
 
 
 #include "macros.h"     // Collected Macros

--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -51,13 +51,28 @@ void draw_string_highlighted(int x, int y, const char *s, unsigned int position)
     return;
 }
 
+/**
+ * Draw text using the Header character set.
+ *
+ * \param x   x-coordinate for displaying the header text.
+ * \param y   y-coordinate for displaying the header text.
+ * \param txt  The text string to display.
+ * \param mode  0 or 1 (Unused).
+ * \param te  Highlight the letter at index te (0-based) in red.
+ */
 void draw_heading(int x, int y, const char *txt, char mode, char te)
 {
     int i, k, l, px;
     struct LET {
         char width, img[15][21];
     } letter;
+    const int letterSize = sizeof(letter.width) + sizeof(letter.img);
     int c;
+
+    if (txt == NULL) {
+        // TODO: This should log an error or throw an exception.
+        return;
+    }
 
     y--;
 
@@ -79,7 +94,11 @@ void draw_heading(int x, int y, const char *txt, char mode, char te)
             px++;
         }
 
-        memcpy(&letter, letter_dat + (sizeof letter * px), sizeof letter); // copy letter over
+        // Read into letter piecewise to avoid packing issues.
+        const char *offset = letter_dat + (letterSize * px);
+        memcpy(&letter.width, offset, sizeof(letter.width));
+        memcpy(&letter.img, offset + sizeof(letter.width),
+               sizeof(letter.img));
 
         for (k = 0; k < 15; k++) {
             for (l = 0; l < letter.width; l++) {

--- a/src/game/gamedata.h
+++ b/src/game/gamedata.h
@@ -80,6 +80,15 @@ extern size_t fwrite_int32_t(const int32_t *src, size_t nelem, FILE *file);
  *       sequence of ReplayItem structures,
  *       each containing offsets to animations.
  * \endverbatim
+ *
+ * \verbatim
+ * File: FAILS.CDR
+ * Desc: Contains mission step failure reports.
+ * Structure:
+ *       uint16_t   -- XXXX count
+ *       sequence of (44) Fdt header structure
+ *       sequence of (925) XFails structures
+ * \endverbatim
  */
 
 struct oLIST {

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -439,16 +439,23 @@ int Help(const char *FName)
 
     fin = sOpen("HELP.CDR", "rb", 0);
     fread(&count, sizeof count, 1, fin);
-    fread(&Pul, sizeof Pul, 1, fin);
     Swap32bit(count);
+
+    if (count <= 0) {
+        // TODO: Add logging statement.
+        return 0;
+    }
 
     i = 0;
 
-    while (xstrncasecmp(Pul.Code, FName, 4) != 0 && i < count) {
-        fread(&Pul, sizeof Pul, 1, fin);
-        i++;
-    }
+    do {
+        fread(&Pul.Code[0], sizeof(Pul.Code), 1, fin);
+        fread(&Pul.offset, sizeof(Pul.offset), 1, fin);
+        fread(&Pul.size, sizeof(Pul.size), 1, fin);
+    } while (xstrncasecmp(Pul.Code, FName, 4) != 0 && i++ < count);
 
+    // This uses short-circuit evaluation to distinguish between
+    // string match and iterator comparison.
     if (i == count) {
         fclose(fin);
         return 0;

--- a/src/game/port.cpp
+++ b/src/game/port.cpp
@@ -162,14 +162,27 @@ struct sIMG sImg, sImgOld;
 uint32_t pTable, pLoc;
 
 
-void
-Seek_sOff(int where)
+/**
+ * Seeks the point in the spot file where
+ *
+ * Seeks in the global FILE sFin and modifies the global var hSPOT.
+ *
+ * \param where  the entry index in the SimpleHdr table.
+ */
+void Seek_sOff(int where)
 {
     fseek(sFin, where * sizeof_SimpleHdr + MSPOT.sOff, SEEK_SET);
     fread_SimpleHdr(&hSPOT, 1, sFin);
     fseek(sFin, hSPOT.offset, SEEK_SET);
 }
 
+/**
+ * Seeks the point in the spot file
+ *
+ * Seeks in the global FILE sFin and modifies the global var pTable.
+ *
+ * \param where  the entry index in the animation table.
+ */
 void Seek_pOff(int where)
 {
     fseek(sFin, where * (sizeof pTable) + (MSPOT.pOff), SEEK_SET);
@@ -204,8 +217,63 @@ char PortSel(char plr, char loc);
 char Request(char plr, char *s, char md);
 size_t ImportPortHeader(FILE *fin, struct PortHeader &target);
 size_t ImportMOBJ(FILE *fin, MOBJ &target);
+size_t ImportSPath(FILE *fin, struct sPATH &target);
 
 
+/**
+ * Animates a Port background activity.
+ *
+ * The main spaceport has a variety of animated activities, some
+ * triggered by player activities, that run in the background.
+ * Examples include planes flying past & rockets being transported
+ * to the main launch pad.
+ *
+ * This function handles animation activity based on the mode:
+ *   - SPOT_LOAD begins an animation sequence, selecting it as the
+ *     active sequence and starting any sound effects.
+ *   - SPOT_STEP plays the next frame in the current animation
+ *     sequence.
+ *   - SPOT_DONE is used when the animation sequence has completed,
+ *     stopping any active sound effects and cleaning up globals.
+ *   - SPOT_KILL terminates any active sound effects and stops
+ *     animation, closing access to the animation file, performing
+ *     less clean up than SPOT_DONE.
+ *
+ * The spots.cdr file is composed of:
+ * SpotHeader
+ * Image Headers
+ * Images
+ * Sequence Directory
+ * <Unknown>
+ * Animation[]
+ *
+ * The SpotHeader (MSPOT) contains offsets to an image headers list and
+ * an animaton sequence directory, and the quantity of animation
+ * sequences.
+ *
+ * The Image Headers list is a SimpleHdr array, accessed via MSPOT.sOff
+ * and read into hSpot. These contain image size and an offset to the
+ * image data.
+ *  - Implementation: spots.cdr has space for 300 SimpleHdr structs
+ *    reserved (1800 bytes); 0-282 have a SimpleHdr defined.
+ *
+ * Images consist of a two-byte sIMG header {width, height} followed by
+ * raw palettized pixel data (coded to the Port palette). The SimpleHdr
+ * size is the length of the pixel data, and does not include the sIMG
+ * header.
+ *
+ * The animation sequence directory is a uint32_t array, accessed via
+ * MSPOT.pOff and read into pTable. It contains offsets to the
+ * animation sequences.
+ *
+ * Each animation sequence consists of a header:
+ *   - char[20] containing the sequence name
+ *   - uint16_t containing the count of sequence parts
+ * followed by a series of sPath objects defining each sequence part.
+ *
+ * \param loc   which spot animation to load when mode=SPOT_LOAD
+ * \param mode  SPOT_LOAD, SPOT_STEP, SPOT_DONE, or SPOT_KILL
+ */
 void SpotCrap(char loc, char mode)
 {
     display::LegacySurface *SP1;
@@ -225,9 +293,16 @@ void SpotCrap(char loc, char mode)
         return;
     }
 
-    if (mode == SPOT_LOAD) { // Open File
+    if (mode == SPOT_LOAD) {
+        // Open File
         sFin = sOpen("SPOTS.CDR", "rb", 0);
-        fread(&MSPOT, sizeof MSPOT, 1, sFin); // Read Header
+
+        // Read in Spot Header
+        // fread(&MSPOT, sizeof MSPOT, 1, sFin);
+        fread(&MSPOT.ID[0], sizeof(MSPOT.ID), 1, sFin);
+        fread(&MSPOT.Qty, sizeof(MSPOT.Qty), 1, sFin);
+        fread(&MSPOT.sOff, sizeof(MSPOT.sOff), 1, sFin);
+        fread(&MSPOT.pOff, sizeof(MSPOT.pOff), 1, sFin);
         Swap32bit(MSPOT.sOff);
         Swap32bit(MSPOT.pOff);
 
@@ -241,21 +316,20 @@ void SpotCrap(char loc, char mode)
         sPathOld.xPut = -1;
         SpotCrap(0, SPOT_STEP);
         // All opened up
-    } else if (mode == SPOT_STEP && sPath.iHold == 1 && sCount > 0) { // Play Next Seq
+    } else if (mode == SPOT_STEP && sPath.iHold == 1 && sCount > 0) {
+        // Play Next Seq
         int xx = 0;
         fseek(sFin, pLoc, SEEK_SET);     // position at next path
-        fread(&sPath, sizeof(sPath), 1, sFin); // get the next sPath struct
-
-        Swap16bit(sPath.Image);
-        Swap16bit(sPath.xPut);
-        Swap16bit(sPath.yPut);
-        Swap16bit(sPath.iHold);
-        SwapFloat(sPath.Scale);
+        // get the next sPATH struct
+        ImportSPath(sFin, sPath);
 
         pLoc = ftell(sFin);               // Path Update Locations
 
         Seek_sOff(sPath.Image);          // point to next image
-        fread(&sImg, sizeof sImg, 1, sFin); // get image header
+        // get image header
+        // fread(&sImg, sizeof sImg, 1, sFin);
+        fread(&sImg.w, sizeof(sImg.w), 1, sFin);
+        fread(&sImg.h, sizeof(sImg.h), 1, sFin);
 
         {
             int expected_w = hSPOT.size / sImg.h;
@@ -266,10 +340,10 @@ void SpotCrap(char loc, char mode)
             }
         }
 
+        // TODO: This makes the previous block obsolete
         sImg.w = hSPOT.size / sImg.h;
         SP1 = new display::LegacySurface(sImg.w, sImg.h);
         fread(SP1->pixels(), hSPOT.size, 1, sFin); // read image data
-
 
         if (sPath.Scale != 1.0) {
             sImg.w = (int)((float) sImg.w * sPath.Scale);
@@ -332,7 +406,8 @@ void SpotCrap(char loc, char mode)
         sPath.iHold--;
     } else if (mode == SPOT_STEP && sPath.iHold == 1 && sCount == 0) {
         SpotCrap(0, SPOT_DONE);
-    } else if ((mode == SPOT_DONE || sCount >= 0) && sFin != NULL) { // Close damn thing down
+    } else if ((mode == SPOT_DONE || sCount >= 0) && sFin != NULL) {
+        // Close the file and stop the audio.
         fclose(sFin);
         sFin = NULL;
         sPathOld.xPut = -1;
@@ -361,7 +436,7 @@ void SpotCrap(char loc, char mode)
 
 #if BABYSND
 
-    if ((loc >= 0 && loc <= 8) || (loc >= 15 && loc <= 19) || loc == 12 || loc == 14 || loc == 11 || loc == 10)
+    if ((loc >= 0 && loc <= 8) || (loc >= 15 && loc <= 19) || loc == 12 || loc == 14 || loc == 11 || loc == 10) {
         if (mode == SPOT_LOAD && !IsChannelMute(AV_SOUND_CHANNEL)) {
             switch (loc) {
             case 1:
@@ -423,7 +498,8 @@ void SpotCrap(char loc, char mode)
             }
 
             turnoff = 1;
-        };
+        }
+    }
 
 #endif
     return;
@@ -541,7 +617,7 @@ void DrawSpaceport(char plr)
     {
         const char *filename =
             (plr == 0 ? "images/usa_port.dat.0.png" :
-                        "images/sov_port.dat.0.png");
+             "images/sov_port.dat.0.png");
         boost::shared_ptr<display::PalettizedSurface> image(
             Filesystem::readImage(filename));
         image->exportPalette();
@@ -1985,7 +2061,7 @@ size_t ImportPortHeader(FILE *fin, struct PortHeader &target)
 
 
 /**
- * Read a PortHeader struct stored as raw data in a file, correcting
+ * Read a MOBJ struct stored as raw data in a file, correcting
  * for endianess.
  *
  * If import is not successful, the contents of the target MOBJ
@@ -2005,19 +2081,19 @@ size_t ImportMOBJ(FILE *fin, MOBJ &target)
 
     for (int i = 0; i < 4 && read; i++) {
         read = read &&
-            fread(&target.Reg[i].qty,
-                  sizeof(target.Reg[i].qty), 1, fin);
+               fread(&target.Reg[i].qty,
+                     sizeof(target.Reg[i].qty), 1, fin);
 
         for (int j = 0; j < 4 && read; j++) {
             read = read &&
-                fread(&target.Reg[i].CD[j].x1,
-                      sizeof(target.Reg[i].CD[j].x1), 1, fin) &&
-                fread(&target.Reg[i].CD[j].y1,
-                      sizeof(target.Reg[i].CD[j].y1), 1, fin) &&
-                fread(&target.Reg[i].CD[j].x2,
-                      sizeof(target.Reg[i].CD[j].x2), 1, fin) &&
-                fread(&target.Reg[i].CD[j].y2,
-                      sizeof(target.Reg[i].CD[j].y2), 1, fin);
+                   fread(&target.Reg[i].CD[j].x1,
+                         sizeof(target.Reg[i].CD[j].x1), 1, fin) &&
+                   fread(&target.Reg[i].CD[j].y1,
+                         sizeof(target.Reg[i].CD[j].y1), 1, fin) &&
+                   fread(&target.Reg[i].CD[j].x2,
+                         sizeof(target.Reg[i].CD[j].x2), 1, fin) &&
+                   fread(&target.Reg[i].CD[j].y2,
+                         sizeof(target.Reg[i].CD[j].y2), 1, fin);
 
             if (read) {
                 Swap16bit(target.Reg[i].CD[j].x1);
@@ -2028,17 +2104,54 @@ size_t ImportMOBJ(FILE *fin, MOBJ &target)
         }
 
         read = read &&
-            fread(&target.Reg[i].iNum,
-                  sizeof(target.Reg[i].iNum), 1, fin) &&
-            fread(&target.Reg[i].sNum,
-                  sizeof(target.Reg[i].sNum), 1, fin) &&
-            fread(&target.Reg[i].PreDraw,
-                  sizeof(target.Reg[i].PreDraw), 1, fin);
+               fread(&target.Reg[i].iNum,
+                     sizeof(target.Reg[i].iNum), 1, fin) &&
+               fread(&target.Reg[i].sNum,
+                     sizeof(target.Reg[i].sNum), 1, fin) &&
+               fread(&target.Reg[i].PreDraw,
+                     sizeof(target.Reg[i].PreDraw), 1, fin);
     }
 
     return (read ? 1 : 0);
 }
 
+/**
+ * Read a sPATH struct stored as raw data in a file, correcting
+ * for endianess.
+ *
+ * If import is not successful, the contents of the target sPATH
+ * are not guaranteed.
+ *
+ * The format of the sPATH is:
+ *   uint16_t Image;        // Which image to Use
+ *   int16_t  xPut, yPut;   // Where to place this image
+ *   int16_t iHold;         // Repeat this # times
+ *   float Scale;       // Scale object
+ *
+ * \param fin  An open port data file at the start of the sPATH data.
+ * \param target  The destination for the read data.
+ * \return  1 if successfully read, 0 otherwise.
+ */
+size_t ImportSPath(FILE *fin, struct sPATH &target)
+{
+    // Chain freads so they stop if one fails...
+    bool read =
+        fread(&target.Image, sizeof(target.Image), 1, fin) &&
+        fread(&target.xPut, sizeof(target.xPut), 1, fin) &&
+        fread(&target.yPut, sizeof(target.yPut), 1, fin) &&
+        fread(&target.iHold, sizeof(target.iHold), 1, fin) &&
+        fread(&target.Scale, sizeof(target.Scale), 1, fin);
+
+    if (read) {
+        Swap16bit(target.Image);
+        Swap16bit(target.xPut);
+        Swap16bit(target.yPut);
+        Swap16bit(target.iHold);
+        Swap32bit(target.Scale);
+    }
+
+    return (read ? 1 : 0);
+}
 
 // Edit r settings {{{
 // ex: ts=4 noet sw=2

--- a/src/game/records.cpp
+++ b/src/game/records.cpp
@@ -23,6 +23,7 @@
 #include "hardef.h"
 #include "draw.h"
 #include "game_main.h"
+#include "endianness.h"
 #include "place.h"
 #include "port.h"
 #include "replay.h"
@@ -48,6 +49,8 @@ void Drec(char *pos, char *pos2, char mde);
 void WriteRecord(int i, int j, int k, int temp);
 void SwapRec(int Rc, int pl1, int pl2);
 char CheckSucess(int i, int j);
+size_t ImportRecordEntry(FILE *fin, Record_Entry &dst);
+size_t ExportRecordEntry(FILE *fout, const Record_Entry &src);
 
 int Pict[56] = {
     411, 2, 1, 177, 272, 275, 409, 501, 504, 507, 414,
@@ -151,10 +154,10 @@ void MakeRecords(void)
                 rec[i][j].country = -1;
                 rec[i][j].tag = rec[i][j].month = rec[i][j].yr = rec[i][j].program = rec[i][j].type = 0;
                 rec[i][j].place = 0;
+
+                ExportRecordEntry(file, rec[i][j]);
             }
         }
-
-        fwrite(rec, sizeof rec, 1, file);
     }
 
     fclose(file);
@@ -165,7 +168,13 @@ void Records(char plr)
     FILE *file;
     char pos = 0, pos2 = 0;
     file = sOpen("RECORDS.DAT", "rb", 1);
-    fread(rec, sizeof rec, 1, file);
+
+    for (int i = 0; i < 56; i++) {
+        for (int j = 0; j < 3; j++) {
+            ImportRecordEntry(file, rec[i][j]);
+        }
+    }
+
     fclose(file);
 
     FadeOut(2, 5, 0, 0);
@@ -253,20 +262,25 @@ void Move2rec(char *pos, char *pos2, char val)
 
 void ClearRecord(char *pos2)
 {
-    int j;
     FILE *file;
-    j = Help("i125");
+    int choice = Help("i125");
 
-    if (j == -1) {
+    if (choice == -1) {
         return;
     }
 
     file = sOpen("RECORDS.DAT", "rb", 1);
-    fread(rec, sizeof rec, 1, file);
+
+    for (int i = 0; i < 56; i++) {
+        for (int j = 0; j < 3; j++) {
+            ImportRecordEntry(file, rec[i][j]);
+        }
+    }
+
     fclose(file);
 
 //clear record
-    for (j = 0; j < 3; j++) {
+    for (int j = 0; j < 3; j++) {
         NREC[*pos2][j] = 0x00;
         rec[*pos2][j].country = -1;
         rec[*pos2][j].tag = rec[*pos2][j].month = rec[*pos2][j].yr = rec[*pos2][j].program = 0;
@@ -285,7 +299,13 @@ void ClearRecord(char *pos2)
     draw_number(12, 90, 3);
 
     file = sOpen("RECORDS.DAT", "wb", 1);
-    fwrite(rec, sizeof rec, 1, file);
+
+    for (int i = 0; i < 56; i++) {
+        for (int j = 0; j < 3; j++) {
+            ExportRecordEntry(file, rec[i][j]);
+        }
+    }
+
     fclose(file);
     return;
 }
@@ -713,7 +733,13 @@ void SafetyRecords(char plr, int temp)
     int j, k;
     FILE *fin, *bo;
     fin = sOpen("RECORDS.DAT", "rb", 1);
-    fread(rec, sizeof rec, 1, fin);
+
+    for (int i = 0; i < 56; i++) {
+        for (j = 0; j < 3; j++) {
+            ImportRecordEntry(fin, rec[i][j]);
+        }
+    }
+
     fclose(fin);
 // deal with case highest safety and lowest safety average
     rec[24][0].type = 3;
@@ -784,7 +810,11 @@ void SafetyRecords(char plr, int temp)
 
     bo = sOpen("RECORDS.DAT", "wb", 1);
 
-    fwrite(rec, sizeof rec, 1, bo);
+    for (int i = 0; i < 56; i++) {
+        for (j = 0; j < 3; j++) {
+            ExportRecordEntry(bo, rec[i][j]);
+        }
+    }
 
     fclose(bo);
 
@@ -814,7 +844,13 @@ void UpdateRecords(char Ty)
     fclose(file);
 
     file = sOpen("RECORDS.DAT", "rb", 1);
-    fread(rec, sizeof rec, 1, file);
+
+    for (i = 0; i < 56; i++) {
+        for (j = 0; j < 3; j++) {
+            ImportRecordEntry(file, rec[i][j]);
+        }
+    }
+
     fclose(file);
 
     for (i = 0; i < NUM_PLAYERS; i++) {
@@ -2008,7 +2044,13 @@ void UpdateRecords(char Ty)
 
     //Change and Update Records
     file = sOpen("RECORDS.DAT", "wb", 1);
-    fwrite(rec, sizeof rec, 1, file);
+
+    for (i = 0; i < 56; i++) {
+        for (j = 0; j < 3; j++) {
+            ExportRecordEntry(file, rec[i][j]);
+        }
+    }
+
     fclose(file);
     return;
 }
@@ -2337,3 +2379,60 @@ void RecChange(int i, int j, int k, int temp, int max, char Rec_Change, char hol
     return;
 }
 
+
+/**
+ * Read packed Record_Entry data from a file into an instance.
+ *
+ * If the entry is not read successfully, reading is stopped.
+ * The entry may be partially read, and the file may be checked
+ * for errors.
+ *
+ * \param fin  an open file handle.
+ * \param dst  where to store the byte data.
+ * \return  1 on success, 0 otherwise.
+ */
+size_t ImportRecordEntry(FILE *fin, Record_Entry &dst)
+{
+    bool success = true &&
+                   fread(&dst.country, sizeof(dst.country), 1, fin) &&
+                   fread(&dst.month, sizeof(dst.month), 1, fin) &&
+                   fread(&dst.yr, sizeof(dst.yr), 1, fin) &&
+                   fread(&dst.program, sizeof(dst.program), 1, fin) &&
+                   fread(&dst.tag, sizeof(dst.tag), 1, fin) &&
+                   fread(&dst.type, sizeof(dst.type), 1, fin) &&
+                   fread(&dst.place, sizeof(dst.place), 1, fin) &&
+                   fread(&dst.name[0], sizeof(dst.name), 1, fin) &&
+                   fread(&dst.astro[0], sizeof(dst.astro), 1, fin);
+
+    Swap16bit(dst.tag);
+    return (success ? 1 : 0);
+}
+
+
+/**
+ * Write a Record_Entry instance as a packed byte stream to a file.
+ *
+ * Outputs using little endian ordering.
+ *
+ * \param fout  an open file handle.
+ * \param src
+ * \return  1 on success, 0 otherwise.
+ */
+size_t ExportRecordEntry(FILE *fout, const Record_Entry &src)
+{
+    uint16_t tempTag = src.tag;
+    Swap16bit(tempTag);
+
+    bool success = true &&
+                   fwrite(&src.country, sizeof(src.country), 1, fout) &&
+                   fwrite(&src.month, sizeof(src.month), 1, fout) &&
+                   fwrite(&src.yr, sizeof(src.yr), 1, fout) &&
+                   fwrite(&src.program, sizeof(src.program), 1, fout) &&
+                   fwrite(&tempTag, sizeof(tempTag), 1, fout) &&
+                   fwrite(&src.type, sizeof(src.type), 1, fout) &&
+                   fwrite(&src.place, sizeof(src.place), 1, fout) &&
+                   fwrite(&src.name[0], sizeof(src.name), 1, fout) &&
+                   fwrite(&src.astro[0], sizeof(src.astro), 1, fout);
+
+    return (success ? 1 : 0);
+}

--- a/src/game/vab.cpp
+++ b/src/game/vab.cpp
@@ -186,20 +186,26 @@ void VVals(char plr, char tx, Equipment *EQ, char v4, char v5);
  */
 void LoadMIVals()
 {
-    size_t MI_size = sizeof(struct MDA) * 28 * 2;
-
     FILE *file = sOpen("VTABLE.DAT", "rb", 0);
-    fread(MI, MI_size, 1, file);
-    fclose(file);
 
-    // Endianness swap
+    // Read in the data & perform Endianness swap
     for (int i = 0; i < 2 * 28; i++) {
+        // struct MDA {
+        //     int16_t x1, y1, x2, y2, yOffset;
+        // } MI[2 * 28];
+        fread(&MI[i].x1, sizeof(MI[i].x1), 1, file);
+        fread(&MI[i].y1, sizeof(MI[i].y1), 1, file);
+        fread(&MI[i].x2, sizeof(MI[i].x2), 1, file);
+        fread(&MI[i].y2, sizeof(MI[i].y2), 1, file);
+        fread(&MI[i].yOffset, sizeof(MI[i].yOffset), 1, file);
         Swap16bit(MI[i].x1);
         Swap16bit(MI[i].y1);
         Swap16bit(MI[i].x2);
         Swap16bit(MI[i].y2);
         Swap16bit(MI[i].yOffset);
     }
+
+    fclose(file);
 }
 
 


### PR DESCRIPTION
Disables the open-ended packing pragma defined in Buzz_inc.h. Reading from files is converted over to individual import functions, rather than reading directly into struct memory spaces, decoupling the struct layout from the file (except for data.h, which uses a pragma internally).