### PR TITLE
Move LoadJsonDowngrades function to downgrader.cpp

### DIFF
--- a/src/game/downgrader.h
+++ b/src/game/downgrader.h
@@ -1,12 +1,10 @@
 #ifndef DOWNGRADER_H
 #define DOWNGRADER_H
 
+#include <string>
 #include <vector>
 
-// Hate including this in the header file, but without it the
-// MissionType structs may be the wrong size.
-// Replace with using pointers? -- rnyoakum
-#include "Buzz_inc.h"
+#include "data.h"
 
 
 /**
@@ -46,6 +44,9 @@ private:
     std::vector<int>::iterator mIndex;
     int mDuration;
 };
+
+
+Downgrader::Options LoadJsonDowngrades(std::string filename);
 
 
 #endif // DOWNGRADER_H

--- a/src/game/rush.cpp
+++ b/src/game/rush.cpp
@@ -23,12 +23,7 @@
 // Programmed by Michael K McCarty
 //
 
-#include <cassert>
-#include <fstream>
-#include <string>
 #include <stdexcept>
-
-#include <json/json.h>
 
 #include "display/graphics.h"
 #include "display/surface.h"
@@ -63,7 +58,6 @@ namespace   // Unnamed namespace part 1
 
 void DrawMissionEntry(char plr, int pad, const struct MissionType &mission);
 void DrawRush(char plr);
-Downgrader::Options LoadJsonDowngrades(std::string filename);
 void ResetRush(int mode, int pad);
 void SetLaunchDates(char plr);
 void SetRush(int mode, int pad);
@@ -319,71 +313,6 @@ void DrawRush(char plr)
     return;
 }
 
-
-/* Read the mission downgrade options from a file.
- *
- * The Json format is:
- * {
- *   "missions": [
- *     { "mission": <Code>, "downgrades": [<Codes>] },
- *     ...
- *   ]
- * }
- *
- * NOTE: I would prefer to put this in downgrader.h/cpp, but the
- *   pragma packing makes that a pain... -- rnyoakum
- *
- * \param filename  A Json-formatted data file.
- * \return  A collection of MissionType.MissionCode-indexed downgrade
- *          options.
- * \throws IOException  If filename is not a readable Json file.
- */
-Downgrader::Options LoadJsonDowngrades(std::string filename)
-{
-    char *path = locate_file(filename.c_str(), FT_DATA);
-
-    if (path == NULL) {
-        free(path);
-        throw IOException(std::string("Unable to open path to ") +
-                          filename);
-    }
-
-    std::ifstream input(path);
-    Json::Value doc;
-    Json::Reader reader;
-    bool success = reader.parse(input, doc);
-
-    if (! success) {
-        free(path);
-        throw IOException("Unable to parse JSON input stream");
-    }
-
-    assert(doc.isObject());
-    Json::Value &missionList = doc["missions"];
-    assert(missionList.isArray());
-
-    Downgrader::Options options;
-
-    for (int i = 0; i < missionList.size(); i++) {
-        Json::Value &missionEntry = missionList[i];
-        assert(missionEntry.isObject());
-
-        int missionCode = missionEntry.get("mission", -1).asInt();
-        assert(missionCode >= 0);
-        // assert(missionCode >= 0 && missionCode <= 61);
-
-        Json::Value &codeGroup = missionEntry["downgrades"];
-        assert(codeGroup.isArray());
-
-        for (int j = 0; j < codeGroup.size(); j++) {
-            options.add(missionCode, codeGroup[j].asInt());
-        }
-    }
-
-    input.close();
-    free(path);
-    return options;
-}
 
 }; // End of Unnamed namespace part 2
 


### PR DESCRIPTION
Consolidates multiple copies of the LoadJsonDowngrades function into a
single version in downgrader.cpp. The Downgrader.h file, where it should
have been declared, included Buzz_inc.h because of pragma packing
issues. To avoid complications from that, two identical copies of the
LoadJsonDowngrade function were declared locally in rush.cpp and
newmis.cpp. Now, with global structure packing disabled by commit
f852876c7eb0fbcfa54d53ceb4d34e5beca8fccb, the declarations have been
consolidated in downgrader.h/.cpp (as is proper).