### PR TITLE
Skip female 'naut requirement for groups IV and V

### DIFF
--- a/src/game/ast1.cpp
+++ b/src/game/ast1.cpp
@@ -617,12 +617,14 @@ void AstSel(char plr)
         MaxMen = 27;
         MaxSel = ASTRO_POOL_LVL4;
         Index = 58;
+        femaleAstronautsRequired = false;
         break;
 
     case 4:
         MaxMen = 19;
         MaxSel = ASTRO_POOL_LVL5;
         Index = 86;
+        femaleAstronautsRequired = false;
         break;
     }
 


### PR DESCRIPTION
Corrects a bug where a female astronaut/cosmonaut requirement could
result in the player getting stuck. Commit
8ea57684b42bd87e2d01caafcf4aeda9cb4c7efa introduced a bug where the news
event requiring female 'nauts was not ignored for groups IV and V,
which contain no female candidates. Consequently, the player would be
locked into the recruitment screen, unable to proceed. This disables the
recruitment requirement for groups IV and V.