### PR TITLE
Fix glitch in display of cash in rdplex

### DIFF
--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -828,3 +828,107 @@ void draw_character(char chr)
         break;
     }
 }
+
+
+/**
+ * Calculate the width a string will occupy on the screen.
+ *
+ * Determines how much screen width a character string would occupy if
+ * sent to the draw_string method.
+ *
+ * \param   a text string
+ * \return  count in pixels.
+ */
+int TextDisplayLength(const char *str)
+{
+    unsigned int pixels = 0;
+    int count = (int) strlen(str);
+
+    for (int i = 0; i < count; i++) {
+
+        switch (toupper(str[i])) {
+        case 'A':
+        case 'B':
+        case 'C':
+        case 'D':
+        case 'E':
+        case 'F':
+        case 'G':
+        case 'H':
+        case 'J':
+        case 'K':
+        case 'L':
+        case 'M':
+        case 'N':
+        case 'O':
+        case 'P':
+        case 'Q':
+        case 'R':
+        case 'S':
+        case 'T':
+        case 'U':
+        case 'V':
+        case 'W':
+        case 'X':
+        case 'Y':
+        case 'Z':
+        case '0':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9':
+        case '+':
+        case '&':
+        case '@':
+        case '#':
+        case '%':
+        case '/':
+        case '<':
+        case '*':
+        case '?':
+            pixels += 6;
+            break;
+
+        case '-':
+            pixels += 5;
+            break;
+
+        case 'I':
+        case '1':
+        case '>':
+            pixels += 4;
+            break;
+
+        case ',':
+        case ' ':
+        case '(':
+        case ')':
+        case '^':  // 3-pixels, no trailing space
+            pixels += 3;
+            break;
+
+        case '.':
+        case ':':
+        case '!':
+        case 0x27:
+        case 0x14:
+            pixels += 2;
+            break;
+
+        default:
+            // Should a message be logged here?
+            break;
+        }
+    }
+
+    // Account for the pixel space after the last character.
+    if (count > 0 && str[count - 1] != '^') {
+        pixels -= 1;
+    }
+
+    return pixels;
+}

--- a/src/game/draw.h
+++ b/src/game/draw.h
@@ -19,5 +19,6 @@ void GradRect(int x1, int y1, int x2, int y2, char plr);
 void draw_small_flag(char plr, int xm, int ym);
 void draw_flag(int x, int y, char plr);
 void draw_character(char chr);
+int TextDisplayLength(const char *str);
 
 #endif // DRAW_H

--- a/src/game/rdplex.cpp
+++ b/src/game/rdplex.cpp
@@ -54,6 +54,7 @@ boost::shared_ptr<display::PalettizedSurface> rd_men;
 void LoadVABPalette(char plr);
 void SRdraw_string(int x, int y, char *text, char fgd, char bck);
 void DrawRD(char plr);
+void DrawCashOnHand(char plr);
 void RDButTxt(int v1, int val, char plr, char SpDModule); //DM Screen, Nikakd, 10/8/10
 void ManSel(int activeButtonIndex);
 void ShowUnit(char hw, char un, char plr);
@@ -226,19 +227,7 @@ void DrawRD(char player_index)
     draw_number(0, 0, Data->Year);
 
     draw_string(200, 9, "CASH:");
-
-    int cshamt = Data->P[player_index].Cash;   // Prepare to center the cash figure under "CASH:"
-    std::string csh = std::to_string(cshamt);
-    size_t ii = std::count(csh.begin(), csh.end(), '1');  // Count number of 1s in cash figure
-    int lencash;
-    if (Data->P[player_index].Cash < 10) {
-        lencash = 1;
-    } else if (Data->P[player_index].Cash > 99) {
-        lencash = 2;
-    } else {
-        lencash = 3;
-    }
-    draw_megabucks(lencash + 198 + ii, 16, Data->P[player_index].Cash);
+    DrawCashOnHand(player_index);
 
     display::graphics.setForegroundColor(1);
     draw_string(258, 13, "CONTINUE");
@@ -248,6 +237,22 @@ void DrawRD(char player_index)
 
     return;
 }  // End of DrawRD
+
+
+/**
+ * Update the player cash on hand in the R&D display.
+ *
+ * \param plr  the player index.
+ */
+void DrawCashOnHand(char plr)
+{
+    char str[10];
+    snprintf(&str[0], 9, "%d MB", Data->P[plr].Cash);
+    fill_rectangle(195, 10, 240, 21, 3);
+    display::graphics.setForegroundColor(11);
+    draw_string(212 - TextDisplayLength(&str[0]) / 2, 16, &str[0]);
+}
+
 
 void
 RDButTxt(int cost, int encodedRolls, char playerIndex, char SpDModule)  //DM Screen, Nikakd, 10/8/10
@@ -790,7 +795,6 @@ void ShowUnit(char hw, char un, char player_index)
     display::graphics.setForegroundColor(1);
 
     fill_rectangle(162, 69, 318, 146, 3);
-    fill_rectangle(198, 10, 238, 21, 3);
     display::graphics.setForegroundColor(1);
     draw_string(170, 97, "INITIAL COST:");
     draw_string(170, 104, "UNIT COST:");
@@ -839,16 +843,7 @@ void ShowUnit(char hw, char un, char player_index)
     display::graphics.setForegroundColor(SCol);
     draw_string(170, 111, "SAFETY FACTOR:");
 
-    display::graphics.setForegroundColor(11);
-
-    if (Data->P[player_index].Cash < 10) {
-        draw_megabucks(202, 16, Data->P[player_index].Cash);
-    } else if (Data->P[player_index].Cash > 99) {
-        draw_megabucks(198, 16, Data->P[player_index].Cash);
-    } else {
-        draw_megabucks(200, 16, Data->P[player_index].Cash);
-    }
-
+    DrawCashOnHand(player_index);
     display::graphics.setForegroundColor(11);
 
     if (!(player_index == 1 && hw == ROCKET_HARDWARE &&
@@ -1078,14 +1073,7 @@ void DrawHPurc(char player_index)
     draw_number(0, 0, Data->Year);
 
     draw_string(200, 9, "CASH:");
-
-    if (Data->P[player_index].Cash < 10) {
-        draw_megabucks(202, 16, Data->P[player_index].Cash);
-    } else if (Data->P[player_index].Cash > 99) {
-        draw_megabucks(198, 16, Data->P[player_index].Cash);
-    } else {
-        draw_megabucks(200, 16, Data->P[player_index].Cash);
-    }
+    DrawCashOnHand(player_index);
 
     display::graphics.setForegroundColor(1);
     draw_string(258, 13, "CONTINUE");


### PR DESCRIPTION
Solves an issue where the R&D / Hardware display was using different
positioning code for the cash-on-hand at different points, resulting in
some text not being correctly refreshed. Also adds a function
TextDisplayLength for calculating the pixel width of a text string.