### PR TITLE
Convert C standard library headers to C++ versions

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1,13 +1,15 @@
 #include "graphics.h"
-#include "surface.h"
-#include "legacy_surface.h"
 
-#include <SDL/SDL.h>
+#include <cassert>
 #include <string>
 #include <vector>
 #include <stdexcept>
-#include <assert.h>
-#include <memory.h>
+#include <memory>
+
+#include <SDL/SDL.h>
+
+#include "surface.h"
+#include "legacy_surface.h"
 
 // FIXME: let's try to avoid this
 #include "../game/sdlhelper.h"

--- a/src/display/image.cpp
+++ b/src/display/image.cpp
@@ -1,17 +1,18 @@
 #include "image.h"
 
+#include <cassert>
+#include <cerrno>
+#include <stdexcept>
+#include <string>
+
+#include <boost/format.hpp>
+#include <png.h>
+#include <zlib.h>
+
 #include "graphics.h"
 #include "surface.h"
 #include "palettized_surface.h"
 
-#include <png.h>
-#include <zlib.h>
-#include <assert.h>
-#include <errno.h>
-
-#include <boost/format.hpp>
-#include <string>
-#include <stdexcept>
 
 namespace display
 {

--- a/src/display/image.h
+++ b/src/display/image.h
@@ -1,14 +1,14 @@
 #ifndef DISPLAY_IMAGE_H
 #define DISPLAY_IMAGE_H
 
+#include <cstdio>
+#include <string>
+#include <SDL/SDL.h>
+
 #include "palette.h"
 #include "graphics.h"
 #include "surface.h"
 #include "palettized_surface.h"
-
-#include <stdio.h>
-#include <string>
-#include <SDL/SDL.h>
 
 #include <boost/shared_ptr.hpp>
 

--- a/src/display/legacy_surface.cpp
+++ b/src/display/legacy_surface.cpp
@@ -1,6 +1,7 @@
 #include "legacy_surface.h"
 
-#include <assert.h>
+#include <cassert>
+
 
 namespace display
 {

--- a/src/display/palette.cpp
+++ b/src/display/palette.cpp
@@ -1,8 +1,10 @@
-#include <memory.h>
-#include <assert.h>
+#include "palette.h"
+
+#include <cassert>
+#include <memory>
 
 #include "graphics.h"
-#include "palette.h"
+
 
 namespace display
 {

--- a/src/display/palette.h
+++ b/src/display/palette.h
@@ -2,9 +2,12 @@
 #define DISPLAY__PALETTE_H
 
 #include "color.h"
-#include <stdio.h>
+
+#include <cassert>
+#include <cstdio>
+
 #include <SDL/SDL.h>
-#include <assert.h>
+
 
 namespace display
 {

--- a/src/display/palettized_surface.cpp
+++ b/src/display/palettized_surface.cpp
@@ -1,6 +1,7 @@
 #include "palettized_surface.h"
 
-#include <assert.h>
+#include <cassert>
+
 
 namespace display
 {

--- a/src/display/surface.cpp
+++ b/src/display/surface.cpp
@@ -1,9 +1,9 @@
-
 #include "surface.h"
 
-#include <SDL/SDL.h>
+#include <cassert>
 #include <algorithm>
-#include <assert.h>
+
+#include <SDL/SDL.h>
 
 namespace display
 {

--- a/src/game/Buzz_inc.h
+++ b/src/game/Buzz_inc.h
@@ -38,9 +38,9 @@ extern "C" {
 #include <winsock2.h>
 #endif
 
-#include <string.h>
-#include <math.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <SDL/SDL_config.h> // declares some of the same symbols as our config
 #include "raceintospace_config.h"
 #include "logging.h"

--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -30,13 +30,15 @@
 // This file handles the Administration building and some of its subsections: Future Missions, Time Capsule (save/load game).
 // It also includes some code for Modem and PBEM.
 
-#include <assert.h>
+#include "admin.h"
+
+#include <cassert>
+#include <cctype>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/palettized_surface.h"
 
-#include "admin.h"
 #include "Buzz_inc.h"
 #include "utils.h"
 #include "ast1.h"
@@ -56,7 +58,6 @@
 #include "endianness.h"
 #include "filesystem.h"
 
-#include <ctype.h>
 
 #define MODEM_ERROR 4
 #define NOTSAME 2

--- a/src/game/admin.h
+++ b/src/game/admin.h
@@ -1,6 +1,9 @@
 #ifndef ADMIN_H
 #define ADMIN_H
 
+#include <stdint.h>
+
+
 void Admin(char plr);
 int32_t EndOfTurnSave(char *inData, int dataLen);  // Create ENDTURN.TMP
 void FileAccess(char mode);

--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -1,18 +1,20 @@
 // This file defines how characters are printed on the screen
 
 #include "draw.h"
-#include "gr.h"
-#include "pace.h"
-#include "sdlhelper.h"
-#include "filesystem.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include "gr.h"
+#include "pace.h"
+#include "sdlhelper.h"
+#include "filesystem.h"
+
 
 /** Print string at specific position
  *

--- a/src/game/endianness.cpp
+++ b/src/game/endianness.cpp
@@ -1,6 +1,8 @@
-#include "Buzz_inc.h"
-#include <assert.h>
 #include "endianness.h"
+
+#include <cassert>
+
+#include "Buzz_inc.h"
 #include "game_main.h"
 
 // Need these functions to always exist

--- a/src/game/file.cpp
+++ b/src/game/file.cpp
@@ -1,9 +1,10 @@
-#include <assert.h>
-#include <physfs.h>
+#include "file.h"
 
+#include <cassert>
 #include <stdexcept>
 
-#include "file.h"
+#include <physfs.h>
+
 
 #define m_phys_handle ((PHYSFS_File*)m_handle)
 

--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -1,13 +1,14 @@
-#include <assert.h>
-#include <physfs.h>
+#include "filesystem.h"
 
+#include <cassert>
 #include <stdexcept>
+
 #include <boost/format.hpp>
+#include <physfs.h>
 
 #include "display/image.h"
 
 #include "raceintospace_config.h"
-#include "filesystem.h"
 
 using boost::format;
 

--- a/src/game/fortify_workaround.cpp
+++ b/src/game/fortify_workaround.cpp
@@ -1,5 +1,7 @@
-#include <stdio.h>
 #include "fortify_workaround.h"
+
+#include <cstdio>
+
 
 #if _FORTIFY_SOURCE > 0
 

--- a/src/game/fortify_workaround.h
+++ b/src/game/fortify_workaround.h
@@ -1,7 +1,7 @@
 #ifndef _FORTIFY_WORKAROUND_
 #define _FORTIFY_WORKAROUND_
 
-#include <stdio.h>
+#include <cstdio>
 
 /*
  * there are over 100 places that call fread without checking the

--- a/src/game/fs.cpp
+++ b/src/game/fs.cpp
@@ -16,20 +16,22 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
-/** \file fs.c
+/** \file fs.cpp
  * Implementation of filesystem access functions.
  *
  */
+
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+
+#include <sys/stat.h>
 
 #include "Buzz_inc.h"
 #include "raceintospace_config.h"
 #include "options.h"
 #include "pace.h"
 #include "utils.h"
-#include <assert.h>
-#include <sys/stat.h>
-#include <errno.h>
-#include <ctype.h>
 
 /** path separator setup */
 #ifndef PATHSEP

--- a/src/game/fs.h
+++ b/src/game/fs.h
@@ -1,7 +1,7 @@
 #ifndef _FS_H
 #define _FS_H
 
-#include <stdio.h>
+#include <cstdio>
 
 /** \file fs.h Definitions for filesystem
  *

--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -21,12 +21,12 @@
 
 #include "future.h"
 
+#include <cassert>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/palettized_surface.h"
 #include "display/legacy_surface.h"
-
-#include <assert.h>
 
 #include "Buzz_inc.h"
 #include "admin.h"

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -26,9 +26,9 @@
 //*                                                              *
 //****************************************************************
 
-#include <errno.h>
-#include <ctype.h>
-#include <assert.h>
+#include <cassert>
+#include <cctype>
+#include <cerrno>
 
 #include "display/graphics.h"
 #include "display/surface.h"
@@ -36,7 +36,7 @@
 
 #include "filesystem.h"
 #include "Buzz_inc.h"
-#include "game_main.h"
+#include "game_main.h" // Below Buzz_inc.h b/c game_main.h needs data.h
 #include "options.h"
 #include "utils.h"
 #include "admin.h"

--- a/src/game/gamedata.cpp
+++ b/src/game/gamedata.cpp
@@ -1,5 +1,7 @@
-#include <stdio.h>
 #include "gamedata.h"
+
+#include <cstdio>
+
 
 static inline uint8_t
 get_uint8_t(const void *buf)

--- a/src/game/gamedata.h
+++ b/src/game/gamedata.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <stdint.h>
-#include <stdio.h>
+
+#include <cstdio>
 
 /** Routines for read/write access to LITTLE ENDIAN data in game files */
 extern size_t fread_uint8_t(uint8_t *dst, size_t nelem, FILE *file);

--- a/src/game/gr.cpp
+++ b/src/game/gr.cpp
@@ -1,12 +1,14 @@
+#include "gr.h"
+
+#include <cassert>
+
+#include <boost/swap.hpp>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 
-#include "gr.h"
 #include "Buzz_inc.h"
-#include <assert.h>
 #include "sdlhelper.h"
-
-#include <boost/swap.hpp>
 
 using boost::swap;
 

--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -26,8 +26,9 @@
 
 // This page handles the Intelligence Briefing
 
-#include <assert.h>
+#include "intel.h"
 
+#include <cassert>
 #include <stdexcept>
 
 #include "display/graphics.h"
@@ -38,7 +39,6 @@
 #include "Buzz_inc.h"
 #include "future.h"
 #include "draw.h"
-#include "intel.h"
 #include "game_main.h"
 #include "place.h"
 #include "port.h"

--- a/src/game/log4c.cpp
+++ b/src/game/log4c.cpp
@@ -32,9 +32,12 @@
  * See log4c.h for documentation.
  */
 #include "logging.h"
+
+#include <cstdlib>
+#include <cassert>
+
 #include "macros.h"
-#include <stdlib.h>
-#include <assert.h>
+
 
 struct LogCategory _LOGV(LOG_ROOT_CAT) = {
     0, 0, 0,

--- a/src/game/log4c.h
+++ b/src/game/log4c.h
@@ -203,7 +203,7 @@
 #ifndef _LOG4C_H_
 #define _LOG4C_H_
 
-#include <stdarg.h>
+#include <cstdarg>
 
 #ifdef ALTERED_STRUCTURE_PACKING
 #error "log4c breaks when you include it late"

--- a/src/game/log_default.cpp
+++ b/src/game/log_default.cpp
@@ -25,8 +25,11 @@
  */
 
 #include "log4c.h"
+
+#include <cstdio>
+
 #include "macros.h"
-#include <stdio.h>
+
 
 /**
  * The root category's default logging function.

--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -25,12 +25,13 @@
 
 // This file handles missions in progress, particularly mission failures and their results
 
-#include <assert.h>
+#include "mis_c.h"
+
+#include <cassert>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 
-#include "mis_c.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "draw.h"

--- a/src/game/mmfile.cpp
+++ b/src/game/mmfile.cpp
@@ -18,16 +18,20 @@
 
 // This file handles multimedia files
 
-#include <math.h>
-#include <assert.h>
-#include <stdio.h>
-#include <memory.h>
-#include <stdlib.h>
-#include <limits.h>
+#include "mmfile.h"
+
+#include <stdint.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <limits>
+
 #include <ogg/ogg.h>
 #include <vorbis/codec.h>
 #include <theora/theora.h>
-#include <stdint.h>
 #include <SDL/SDL.h>
 
 #include "raceintospace_config.h"
@@ -38,7 +42,6 @@
 #include "fake_unistd.h"
 #endif
 
-#include "mmfile.h"
 #include "macros.h"
 #include "utils.h"
 #include "logging.h"

--- a/src/game/mmfile.h
+++ b/src/game/mmfile.h
@@ -1,11 +1,14 @@
 #ifndef _MM_FILE_H
 #define _MM_FILE_H
 
-#include <stdio.h>
+#include <cstdio>
+
 #include <ogg/ogg.h>
 #include <vorbis/codec.h>
 #include <theora/theora.h>
 #include <SDL/SDL.h>
+
+
 enum stream_type {
     MEDIA_AUDIO = 1,
 

--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -18,20 +18,23 @@
 
 // This file handles Advanced Preferences.
 
-#include "Buzz_inc.h"
 #include "options.h"
+
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <SDL/SDL.h>
+
+#include "Buzz_inc.h"
 #include "macros.h"
 #include "pace.h"
 #include "fs.h"
 #include "utils.h"
 #include "logging.h"
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <SDL/SDL.h>
 
 #define ENVIRON_DATADIR ("BARIS_DATA")
 #define ENVIRON_SAVEDIR ("BARIS_SAVE")

--- a/src/game/pace.cpp
+++ b/src/game/pace.cpp
@@ -1,19 +1,20 @@
 // This file is something to do with processing audio files
 
-#include <assert.h>
+#include "pace.h"
+
+#include <cassert>
+#include <cctype>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 
 #include "Buzz_inc.h"
-#include "pace.h"
 #include "utils.h"
 #include "game_main.h"
 #include "sdlhelper.h"
 #include "gr.h"
 #include "mmfile.h"
 
-#include <ctype.h>
 
 void randomize(void);
 void SMove(void *p, int x, int y);

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -18,7 +18,9 @@
 
 // This file shows the Mission Review (the summary you see at the end of a mission).
 
-#include <assert.h>
+#include "place.h"
+
+#include <cassert>
 #include <boost/format.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -27,7 +29,6 @@
 #include "display/surface.h"
 #include "display/palettized_surface.h"
 
-#include "place.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "draw.h"

--- a/src/game/port.cpp
+++ b/src/game/port.cpp
@@ -25,11 +25,16 @@
 
 // This file handles the main Spaceport screen, including animations
 
+#include "port.h"
+
+#include <cstdio>
+
+#include <boost/shared_ptr.hpp>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include "port.h"
 #include "Buzz_inc.h"
 #include "draw.h"
 #include "utils.h"
@@ -54,9 +59,6 @@
 #include "pace.h"
 #include "endianness.h"
 #include "filesystem.h"
-
-#include <stdio.h>
-#include <boost/shared_ptr.hpp>
 
 #define LET_A   0x09
 #define LET_M   0x0A

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -25,11 +25,14 @@
 
 // This file handles original (main) game Preferences
 
+#include "prefs.h"
+
+#include <cctype>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include "prefs.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "draw.h"
@@ -41,7 +44,6 @@
 #include "pace.h"
 #include "filesystem.h"
 
-#include <ctype.h>
 
 struct DisplayContext {
     boost::shared_ptr<display::PalettizedSurface> prefs_image;

--- a/src/game/randomize.cpp
+++ b/src/game/randomize.cpp
@@ -34,19 +34,21 @@ Unit Cost is loosely based on the Basic Model, but depends on initial cost
 RD cost is loosely based on the Basic Model
 */
 
+#include "randomize.h"
+
+#include <cassert>
+#include <cctype>
+
 #include "display/graphics.h"
 
-#include "randomize.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
-#include <assert.h>
 #include "game_main.h"
 #include "gr.h"
 #include "draw.h"
 #include "pace.h"
 #include "sdlhelper.h"
 
-#include <ctype.h>
 
 /*random_number divides the randomization in 2,
  so there is a lower chance of getting an extreme */

--- a/src/game/rdplex.cpp
+++ b/src/game/rdplex.cpp
@@ -27,11 +27,14 @@
 
 // This file handles the R&D and Purchasing Facilities, and Technology Transfer
 
+#include "rdplex.h"
+
+#include <cassert>
+
 #include "display/graphics.h"
 #include "display/palettized_surface.h"
 
 #include "Buzz_inc.h"
-#include "rdplex.h"
 #include "options.h"
 #include "draw.h"
 #include "ast4.h"
@@ -41,7 +44,6 @@
 #include "gr.h"
 #include "pace.h"
 #include "endianness.h"
-#include <assert.h>
 #include "filesystem.h"
 #include "hardware_buttons.h"
 #include "hardware.h"

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -25,11 +25,12 @@
 
 // This file handles replay of missions (I think).
 
-#include <assert.h>
+#include "replay.h"
+
+#include <cassert>
 
 #include "display/graphics.h"
 
-#include "replay.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "mmfile.h"

--- a/src/game/roster.cpp
+++ b/src/game/roster.cpp
@@ -1,11 +1,12 @@
-#include <json/json.h>
-#include <assert.h>
+#include "roster.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <fstream>
 
 #include <boost/foreach.hpp>
+#include <json/json.h>
 
-#include <fstream>
-#include <stdlib.h>
-#include "roster.h"
 #include "fs.h"
 
 Roster::Roster(std::istream &input_stream)

--- a/src/game/roster_entry.cpp
+++ b/src/game/roster_entry.cpp
@@ -1,9 +1,9 @@
 #include "roster_entry.h"
+
+#include <cassert>
+#include <cstring>
+
 #include "roster_group.h"
-
-#include <assert.h>
-#include <string.h>
-
 #include "options.h"
 #include "pace.h"
 

--- a/src/game/roster_group.cpp
+++ b/src/game/roster_group.cpp
@@ -1,6 +1,7 @@
 #include "roster_group.h"
 
-#include <assert.h>
+#include <cassert>
+
 #include <boost/foreach.hpp>
 
 RosterGroup::RosterGroup(int player, int group_number, const Json::Value &json_object)

--- a/src/game/sdlhelper.cpp
+++ b/src/game/sdlhelper.cpp
@@ -26,16 +26,19 @@
 
 // This file helps with processing A/V.
 
+#include "sdlhelper.h"
+
+#include <cassert>
+#include <memory>
+
+#include <SDL/SDL.h>
 #include "display/graphics.h"
 #include "display/surface.h"
 
-#include "sdlhelper.h"
-#include <assert.h>
-#include <memory.h>
-#include <SDL/SDL.h>
 #include "Buzz_inc.h"
 #include "options.h"
 #include "utils.h"
+
 
 #define MAX_X   320
 #define MAX_Y   200

--- a/src/game/start.cpp
+++ b/src/game/start.cpp
@@ -25,9 +25,10 @@
 
 // This file handles start-of-turn events: adjusting 'naut morale, etc.
 
-#include <assert.h>
-
 #include "start.h"
+
+#include <cassert>
+
 #include "pace.h"
 #include "Buzz_inc.h"
 #include "options.h"

--- a/src/game/utils.cpp
+++ b/src/game/utils.cpp
@@ -1,10 +1,12 @@
 #include "utils.h"
+
+#include <cassert>
+#include <cerrno>
+#include <cctype>
+#include <cstring>
+#include <memory>
+
 #include "logging.h"
-#include <assert.h>
-#include <errno.h>
-#include <ctype.h>
-#include <string.h>
-#include <memory.h>
 #include "raceintospace_config.h"
 
 #ifdef HAVE_SYS_TYPES_H

--- a/src/game/utils.h
+++ b/src/game/utils.h
@@ -1,9 +1,10 @@
 #ifndef _UTILS_H
 #define _UTILS_H
 
+#include <cstdio>
+#include <cstdlib>
+
 #include <sys/types.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "raceintospace_config.h"
 

--- a/src/utils/data_decoder.cpp
+++ b/src/utils/data_decoder.cpp
@@ -1,11 +1,12 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdint.h>
-#include <errno.h>
-#include <string.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <jsoncpp/json/json.h>
-#include <assert.h>
 
 void print_escaped_string(const char *string, int max_length)
 {

--- a/src/utils/news2png.cpp
+++ b/src/utils/news2png.cpp
@@ -1,6 +1,7 @@
-#include <errno.h>
 #include <stdint.h>
-#include <stdio.h>
+
+#include <cerrno>
+#include <cstdio>
 #include <sstream>
 
 #include <png.h>


### PR DESCRIPTION
Replace C headers with their C++ versions. Per the C++ standard, the C++
version is preferred except when maintaining strict compatability with
C, which RIS does not. This will hopefully resolve some
compiler-dependent issues.