### PR TITLE
Fix music sequence constants for macOS

### DIFF
--- a/src/game/platform_macosx/music_osx.cpp
+++ b/src/game/platform_macosx/music_osx.cpp
@@ -35,7 +35,7 @@ extern "C" {
 #include "music.h"
 #include "logging.h"
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 1090
+#if MAC_OS_X_VERSION_MAX_ALLOWED < 101100
 #define kMusicSequenceFile_AnyType 0
 #define kMusicSequenceLoadSMF_PreserveTracks 0
 #endif


### PR DESCRIPTION
I misread the documentation, but it [clearly](https://developer.apple.com/documentation/audiotoolbox/musicsequenceloadflags/kmusicsequenceloadsmf_preservetracks) [shows](https://developer.apple.com/documentation/audiotoolbox/musicsequencefiletypeid/kmusicsequencefile_anytype) that the constants were actually introduced in the OS X 10.11 SDK.