### PR TITLE
Add library dependencies for std functions

### DIFF
--- a/src/display/legacy_surface.cpp
+++ b/src/display/legacy_surface.cpp
@@ -2,6 +2,9 @@
 
 #include <assert.h>
 
+#include <cstdlib>
+#include <algorithm>
+
 namespace display
 {
 


### PR DESCRIPTION
Includes the C++ standard libraries containing std::abs, std::max,
std::min, and std::swap explicitly in legacy_surface.cpp, rather than
relying on other includes. This resolves issue #362.