### PR TITLE
Update SDLMain for macOS

### DIFF
--- a/src/game/platform_macosx/SDLMain.h
+++ b/src/game/platform_macosx/SDLMain.h
@@ -5,6 +5,9 @@
     Feel free to customize this file to suit your needs
 */
 
+#ifndef _SDLMain_h_
+#define _SDLMain_h_
+
 #import <Cocoa/Cocoa.h>
 
 @interface SDLMain : NSObject
@@ -12,3 +15,5 @@
 - (IBAction)help:(id)sender;
 - (IBAction)enableCrashReporting:(id)sender;
 @end
+
+#endif /* _SDLMain_h_ */

--- a/src/game/platform_macosx/SDLMain.m
+++ b/src/game/platform_macosx/SDLMain.m
@@ -7,6 +7,8 @@
 
 #include "SDLMain.h"
 #import <SDL.h>
+#import <sys/param.h> /* for MAXPATHLEN */
+#import <unistd.h>
 
 //#import "SmartCrashReportsInstall.h"
 

--- a/src/game/platform_macosx/SDLMain.m
+++ b/src/game/platform_macosx/SDLMain.m
@@ -6,9 +6,9 @@
 */
 
 #include "SDLMain.h"
-#import <SDL.h>
-#import <sys/param.h> /* for MAXPATHLEN */
-#import <unistd.h>
+#include <SDL.h>
+#include <sys/param.h> /* for MAXPATHLEN */
+#include <unistd.h>
 
 //#import "SmartCrashReportsInstall.h"
 

--- a/src/game/platform_macosx/SDLMain.m
+++ b/src/game/platform_macosx/SDLMain.m
@@ -181,12 +181,33 @@ int SDL_main(int argc, char * argv[])
 #undef main
 #endif
 
+static int IsRootCwd()
+{
+    char buf[MAXPATHLEN];
+    char *cwd = getcwd(buf, sizeof (buf));
+    return (cwd && (strcmp(cwd, "/") == 0));
+}
+
+static int IsFinderLaunch(const int argc, const char *argv[])
+{
+    /* -psn_XXX is passed if we are launched from Finder, SOMETIMES */
+    if ( (argc >= 2) && (strncmp(argv[1], "-psn", 4) == 0) ) {
+        return 1;
+    } else if ((argc == 1) && IsRootCwd()) {
+        /* we might still be launched from the Finder; on 10.9+, you might not
+        get the -psn command line anymore. If there's no
+        command line, and if our current working directory is "/", it
+        might as well be a Finder launch. */
+        return 1;
+    }
+    return 0;  /* not a Finder launch. */
+}
+
 /* Main entry point to executable - should *not* be SDL_main! */
 int main (int argc,  const char *argv[])
 {
     /* Copy the arguments into a global variable */
-    /* This is passed if we are launched by double-clicking */
-    if ( argc >= 2 && strncmp (argv[1], "-psn", 4) == 0 ) {
+    if (IsFinderLaunch(argc, argv)) {
         gArgv = (char **) SDL_malloc(sizeof (char *) * 2);
         gArgv[0] = (char *)argv[0];
         gArgv[1] = NULL;


### PR DESCRIPTION
This PR updates SDLMain for macOS.

First it reverts part of a cleanup commit that removed two header includes from SDLMain. Turns out one of the headers was needed to build successfully on Mac OS X 10.6. I brought back the other header as well because upstream SDL developers probably put it there for a reason.

Then I added commits to bring in other changes upstream SDL made.

The [one remaining upstream change](https://hg.libsdl.org/SDL/rev/1496aa09e41e) turns out to [be bad](https://stackoverflow.com/questions/14409492/xcode-implementing-a-method-also-be-implemented-by-its-primary-class) so I'm not including it here.