### PR TITLE
Update Info.plist

### DIFF
--- a/src/game/platform_macosx/Info.plist.in
+++ b/src/game/platform_macosx/Info.plist.in
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundleDocumentTypes</key>
 	<array/>
 	<key>CFBundleExecutable</key>

--- a/src/game/platform_macosx/Info.plist.in
+++ b/src/game/platform_macosx/Info.plist.in
@@ -14,8 +14,6 @@
 	<string>org.raceintospace.RaceIntoSpace</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleLongVersionString</key>
-	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
 	<key>CFBundleShortVersionString</key>
 	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
 	<key>CFBundleVersion</key>

--- a/src/game/platform_macosx/platform.cmake
+++ b/src/game/platform_macosx/platform.cmake
@@ -53,4 +53,7 @@ add_dependencies("${app}" libs)
 
 set_target_properties("${app}" PROPERTIES
   MACOSX_BUNDLE_INFO_PLIST ${PROJECT_SOURCE_DIR}/src/game/platform_macosx/Info.plist.in
+  MACOSX_BUNDLE_BUNDLE_NAME ${app}
+  MACOSX_BUNDLE_BUNDLE_VERSION ${CMAKE_PROJECT_VERSION}
+  MACOSX_BUNDLE_SHORT_VERSION_STRING ${CMAKE_PROJECT_VERSION}
   )


### PR DESCRIPTION
This PR modifies the build to actually populate the CFBundleName, CFBundleVersion and CFBundleShortVersionString keys in the Info.plist and adds the new CFBundleDisplayName key. It also removes the obsolete CFBundleLongVersionString key.