### PR TITLE
Move FM flight path code to futbub

### DIFF
--- a/src/game/futbub.h
+++ b/src/game/futbub.h
@@ -1,30 +1,10 @@
 #ifndef FUTBUB_H
 #define FUTBUB_H
 
-void Draw_IJ(char w);
-void Draw_IJV(char w);
-void OrbOut(char a, char b, char c);
-void LefEarth(char a, char b);
-void OrbIn(char a, char b, char c);
-void OrbMid(char a, char b, char c, char d);
-void LefOrb(char a, char b, char c, char d);
-void Draw_LowS(char a, char b, char c, char x, char y, char z);
-void Fly_By(void);
-void VenMarMerc(char x);
-void Draw_PQR(void);
-void Draw_PST(void);
-void Draw_GH(char a, char b);
-void Q_Patch(void);
-void RghtMoon(char x, char y);
-void DrawLunPas(char x, char y, char z, char w);
-void DrawLefMoon(char x, char y);
-void DrawSTUV(char x, char y, char z, char w);
-void Draw_HighS(char x, char y, char z);
-void DrawMoon(char x, char y, char z, char w, char j, char k, char l);
-void LefGap(char x);
-void S_Patch(char x);
-void DrawZ(void);
-
-extern int Bub_Count;
+void DecreasePathResolution();
+char GetBubbleAt(int x, int y);
+void IncreasePathResolution();
+void MissionPath(char plr, int val, int pad);
+int MissionStepsDrawn();
 
 #endif // FUTBUB_H

--- a/src/game/future.h
+++ b/src/game/future.h
@@ -1,7 +1,6 @@
 #ifndef FUTURE_H
 #define FUTURE_H
 
-void Bd(int x, int y);
 void Future(char plr);
 void MissionName(int val, int xx, int yy, int len);
 

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -97,7 +97,6 @@ char pNeg[NUM_PLAYERS][MAX_MISSIONS];
 int32_t xMODE;
 char MAIL = -1;
 char Option = -1;
-int SEG = 15;
 int fOFF = -1;
 struct cdtable *cdt;
 bool fullscreenMissionPlayback;    /**< true for fullscreen mission playback, false otherwise */

--- a/src/game/game_main.h
+++ b/src/game/game_main.h
@@ -24,7 +24,6 @@ extern int fOFF;
 extern char AI[2];
 extern char manOnMoon;
 extern char dayOnMoon;
-extern int SEG;
 extern display::LegacySurface *vhptr;
 extern bool fullscreenMissionPlayback;
 extern char pNeg[NUM_PLAYERS][MAX_MISSIONS];

--- a/src/game/proto.h
+++ b/src/game/proto.h
@@ -21,7 +21,6 @@
 // ***************************
 
 #define BUFFER_SIZE 20*1024   /**< Allocated Buffer in Beginning */
-#define MAXBUB 30             /**< Maximum Bubbles */
 #define pline(a,b,c,d)        {grMoveTo(a,b) ; grLineTo(c,d);}
 #define other(a)          abs( (a)-1 )
 #define minn(a,b)         (((a) < (b)) ? (a) : (b))


### PR DESCRIPTION
Modularizes the flight path illustration code by moving MissionPath and
several global values to futbub.cpp. This change allows the component
functions used for drawing flight path sections (and several globals) to
be hidden within futbub.cpp entirely.