### PR TITLE
Replace MisRandom() mission random number generator

### DIFF
--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -928,17 +928,36 @@ void GetMisType(char mcode)
 }
 
 
+/* Mission random number generator used on level 1. For random numbers
+ * above brandom_threshold, there is a second roll of a Gaussian
+ * random number generator that is slightly biased against high
+ * numbers.
+ */
 int MisRandom(void)
 {
-    int i, nval;
+    const double mu = 57;
+    const double sigma = sqrt(1000);
+    const int brandom_threshold = 65;
+    int r_uniform;
+    double u1, u2, r_gaussian;
+
+    r_uniform = brandom(100) + 1;
+
+    if (r_uniform < brandom_threshold) {
+        return r_uniform;
+    }
 
     do {
-        nval = 107;
+        // Generate two uniformly distributed random numbers.
+        u1 = rand() / (double) RAND_MAX;
+        u2 = rand() / (double) RAND_MAX;
 
-        for (i = 0; i < 250; i++) {
-            nval += (brandom(7) - 3);
-        }
-    } while (nval < 50 || nval > 150);
+        // Box-Muller transform to obtain a Gaussian random variable
+        // with mean mu and standard deviation sigma.
 
-    return nval - 50;
+        r_gaussian = sigma * sqrt(-2 * log(u1)) * cos(2 * M_PI * u2) + mu;
+
+    } while ((r_gaussian > 100) || (r_gaussian < brandom_threshold));
+
+    return (int)(r_gaussian + 0.5); // Return nearest integer value.
 }

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -937,7 +937,7 @@ int MisRandom(void)
 {
     const double mu = 57;
     const double sigma = sqrt(1000);
-    const int brandom_threshold = 65;
+    const int brandom_threshold = 66;
     int r_uniform;
     double u1, u2, r_gaussian;
 
@@ -953,11 +953,12 @@ int MisRandom(void)
         u2 = rand() / (double) RAND_MAX;
 
         // Box-Muller transform to obtain a Gaussian random variable
-        // with mean mu and standard deviation sigma.
+        // with mean mu and standard deviation sigma. A value of 0.5
+        // is added to ensure correct rounding.
 
-        r_gaussian = sigma * sqrt(-2 * log(u1)) * cos(2 * M_PI * u2) + mu;
+        r_gaussian = sigma * sqrt(-2 * log(u1)) * cos(2 * M_PI * u2) + mu + 0.5;
 
-    } while ((r_gaussian > 100) || (r_gaussian < brandom_threshold));
+    } while ((r_gaussian >= 101) || (r_gaussian < brandom_threshold));
 
-    return (int)(r_gaussian + 0.5); // Return nearest integer value.
+    return (int) r_gaussian;
 }


### PR DESCRIPTION
Improved version of MisRandom() that returns uniformly distributed
values below 65 and Gaussian random numbers essentially identical to the
old code above 65. This ensures that rolls at low safety values (e.g.,
for the first docking attempts) are not harder on level 1 than on the
other levels. Resolves #399.