### PR TITLE
Use endurance attribute

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -466,7 +466,8 @@ void MissionSteps(char plr, int mcode, int Mgoto, int step, int pad)
             case 10: // durations
                 Mev[step].Class = Mission_Capsule;
                 Mev[step].ast = -1;
-                Mev[step].asf = CrewEndurance(MA[pad], MANNED[pad]);
+                Mev[step].asf = options.feat_use_endurance
+                                ? CrewEndurance(MA[pad], MANNED[pad]) : 0;
                 break;
 
             default: // remaining

--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -26,6 +26,9 @@
 // This file handles part of Mission Control during missions
 
 #include "mc2.h"
+
+#include <cassert>
+
 #include "Buzz_inc.h"
 #include "options.h"
 #include "game_main.h"
@@ -35,6 +38,7 @@
 
 LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT)
 
+int CrewEndurance(const struct MisAst *crew, size_t crewSize);
 void MissionParse(char plr, char *MCode, char *LCode, char pad);
 char WhichPart(char plr, int which);
 void MissionSteps(char plr, int mcode, int Mgoto, int step, int pad);
@@ -50,6 +54,22 @@ void MissionCodes(char plr, char val, char pad)
     MissionParse(plr, Mis.Code, Mis.Alt, pad);
     return;
 }
+
+
+int CrewEndurance(const struct MisAst *crew, size_t crewSize)
+{
+    assert(crew);
+
+    int value = 0;
+
+    for (size_t i = 0; i < crewSize; i++) {
+        assert(crew[i].A);
+        value += crew[i].A->Endurance;
+    }
+
+    return int((double(value) / double(crewSize)) + 0.5);
+}
+
 
 void
 MissionParse(char plr, char *MCode, char *LCode, char pad)
@@ -446,7 +466,7 @@ void MissionSteps(char plr, int mcode, int Mgoto, int step, int pad)
             case 10: // durations
                 Mev[step].Class = Mission_Capsule;
                 Mev[step].ast = -1;
-                Mev[step].asf = 0;
+                Mev[step].asf = CrewEndurance(MA[pad], MANNED[pad]);
                 break;
 
             default: // remaining

--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -151,6 +151,12 @@ static struct {
         "setting\n# where only Capsule and Endurance are shown."
     },   // Depending on difficulty, show recruit's Docking, EVA, LM
     {
+        "use_endurance", &options.feat_use_endurance, "%u", 1,
+        "Add the crew's endurance when making duration tests, and when "
+        "avoiding injury.\n# Set to 0 to disabled (Classic setting)."
+
+    },
+    {
         "cheat_no_damage", &options.cheat_no_damage, "%u", 0,
         "Set to non-zero to disable damaged equipment (will prevent future damage)."
     },
@@ -449,6 +455,7 @@ void ResetToDefaultOptions()
     //No Backup crew required -Leon
     options.feat_no_backup = 1;
     options.feat_show_recruit_stats = 1;
+    options.feat_use_endurance = 1;
     options.feat_random_eq = 0;
     options.feat_eq_new_name = 0;
     options.boosterSafety = 0;
@@ -470,13 +477,14 @@ void ResetToDefaultOptions()
  */
 void ResetToClassicOptions()
 {
+    options.boosterSafety = 2;
     options.feat_shorter_advanced_training = 0;
     options.feat_female_nauts = 0;
     options.feat_compat_nauts = 10;
     options.feat_no_cTraining = 0;
     options.feat_no_backup = 0;
     options.feat_show_recruit_stats = 0;
-    options.boosterSafety = 2;
+    options.feat_use_endurance = 0;
 
     // These may not be implemented, but disable anyways...
     options.feat_random_nauts = 0;

--- a/src/game/options.h
+++ b/src/game/options.h
@@ -17,6 +17,7 @@ typedef struct {
     unsigned feat_no_cTraining;
     unsigned feat_no_backup;
     unsigned feat_show_recruit_stats;
+    unsigned feat_use_endurance;
     unsigned cheat_no_damage;
     unsigned feat_random_eq;
     unsigned feat_eq_new_name;

--- a/src/game/start.cpp
+++ b/src/game/start.cpp
@@ -376,8 +376,12 @@ AstroTurn(void)
 
                     if (num > 94) {
                         num = brandom(100);
+                        int enduranceFactor =
+                            options.feat_use_endurance
+                            ? 10 * MAX(0, Data->P[j].Pool[i].Endurance)
+                            : 0;
 
-                        if (num > (74 - 10 * MAX(0, Data->P[j].Pool[i].Endurance))) {
+                        if (num > (74 - enduranceFactor)) {
                             Data->P[j].Pool[i].Status = AST_ST_INJURED;
                             Data->P[j].Pool[i].InjuryDelay = 2;
                             Data->P[j].Pool[i].Special = 9;

--- a/src/game/start.cpp
+++ b/src/game/start.cpp
@@ -377,7 +377,7 @@ AstroTurn(void)
                     if (num > 94) {
                         num = brandom(100);
 
-                        if (num > 74) {
+                        if (num > (74 - 10 * MAX(0, Data->P[j].Pool[i].Endurance))) {
                             Data->P[j].Pool[i].Status = AST_ST_INJURED;
                             Data->P[j].Pool[i].InjuryDelay = 2;
                             Data->P[j].Pool[i].Special = 9;


### PR DESCRIPTION
While astronauts/cosmonauts have five stats, the Endurance attribute never provided any penalty or benefit. This uses Endurance to provide a skill bonus on duration steps and affects the odds of a training washout resulting in injury or retirement.