### PR TITLE
Fix lunar recon bug

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -1125,7 +1125,7 @@ int U_AllotPrest(char plr, char mis)
     lun = Check_Photo();
 
     // Don't improve photo recon twice in mail games
-    if (!(MAIL == 1 && plr == 0)) {
+    if (MAIL == 1 && plr == 0) {
         lun = 0;
     }
 


### PR DESCRIPTION
Fixes the bug that unmanned lunar reconnaissance missions were not properly updating photo recon level. Resolves #427.