### PR TITLE
Fix VAB display for damaged rockets

### DIFF
--- a/src/game/vehicle.cpp
+++ b/src/game/vehicle.cpp
@@ -133,7 +133,7 @@ int Vehicle::available() const
 
 bool Vehicle::damaged() const
 {
-    return mPrimary->Damage > 0 || (mSecondary && mSecondary->Damage > 0);
+    return mPrimary->Damage || (mSecondary && mSecondary->Damage);
 }
 
 


### PR DESCRIPTION
Displays the rocket safety factor in red in the VAB when the rocket is
damaged. Due to a bug in 66684f1c6154e17ae727c1d750de26783f6b424a,
launch vehicle damage was not being reported properly; the test expected
damage to be stored as a positive quantity but it is stored as a
negative modifier.