### PR TITLE
Use draw_number rather than converting to char[]

### DIFF
--- a/src/game/ast4.cpp
+++ b/src/game/ast4.cpp
@@ -403,7 +403,7 @@ void FixPrograms(char plr)
 void DamProb(char plr, char prog, int chk)
 {
     int D_Cost, Saf_Loss, ESafety;
-    char Digit[4], Name[30];
+    char Name[30];
 
     Saf_Loss = D_Cost = ESafety = 0;
 
@@ -447,19 +447,16 @@ void DamProb(char plr, char prog, int chk)
     display::graphics.setForegroundColor(6);
     draw_string(121, 113, "DAMAGE COST: ");
     display::graphics.setForegroundColor(1);
-    snprintf(&Digit[0], sizeof(Digit), "%d", D_Cost);
-    draw_string(0, 0, &Digit[0]);
+    draw_number(0, 0, D_Cost);
     draw_string(0, 0, " M.B.  (OF ");
     draw_megabucks(0, 0, Data->P[plr].Cash);
     draw_string(0, 0, ")");
     display::graphics.setForegroundColor(6);
     draw_string(121, 122, "SAFETY LOSS: ");
     display::graphics.setForegroundColor(1);
-    snprintf(&Digit[0], sizeof(Digit), "%d", Saf_Loss);
-    draw_string(0, 0, &Digit[0]);
+    draw_number(0, 0, Saf_Loss);
     draw_string(0, 0, "%  (FROM ");
-    snprintf(&Digit[0], sizeof(Digit), "%d", ESafety);
-    draw_string(0, 0, &Digit[0]);
+    draw_number(0, 0, ESafety);
     draw_string(0, 0, "%)");
     FadeIn(2, 10, 0, 0);
 

--- a/src/game/hardef.cpp
+++ b/src/game/hardef.cpp
@@ -1551,7 +1551,6 @@ DrawRank(char plr)
 {
     int i, MaxPz = 0, MaxNg = 0, Px, Py, t1, t2, Cur = 0, OffSet, Year_Inc =
                                   12, score;
-    char Digit[4];
 
     helpText = "i030";
     keyHelpText = "k030";
@@ -1710,8 +1709,7 @@ DrawRank(char plr)
         display::graphics.setForegroundColor(1);
         draw_string(60, 27, "SCORE:");
         score = CalcScore(0, Data->Def.Lev1, Data->Def.Lev2);
-        snprintf(&Digit[0], sizeof(Digit), "%d", score);
-        draw_string(95, 27, &Digit[0]);
+        draw_number(95, 27, score);
     }
 
     if (Option == -1 || Option == 1) {
@@ -1719,10 +1717,8 @@ DrawRank(char plr)
         display::graphics.setForegroundColor(1);
         draw_string(208, 27, "SCORE:");
         score = CalcScore(1, Data->Def.Lev2, Data->Def.Lev1);
-        snprintf(&Digit[0], sizeof(Digit), "%d", score);
-        draw_string(243, 27, &Digit[0]);
+        draw_number(243, 27, score);
     }
-
 }
 
 int

--- a/src/game/newmis.cpp
+++ b/src/game/newmis.cpp
@@ -184,7 +184,7 @@ void MisOrd(char num)
 void MisAnn(char plr, char pad)
 {
     int i, j, bud;
-    char k, hold, Digit[4], HelpFlag = 0;
+    char k, hold, HelpFlag = 0;
     char pad_str[2] = {static_cast<char>('A' + pad), '\0'};
 
     display::graphics.screen()->clear();
@@ -334,12 +334,9 @@ void MisAnn(char plr, char pad)
                     display::graphics.setForegroundColor(11);
                     draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                     Data->P[plr].Manned[hold].Damage != 0 ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment, Nikakd, 10/8/10
-                    snprintf(&Digit[0], sizeof(Digit), "%d",
-                             Data->P[plr].Manned[hold].Safety +
-                             Data->P[plr].Manned[hold].Damage);
-                    draw_string(0, 0, &Digit[0]);
+                    draw_number(0, 0, Data->P[plr].Manned[hold].Safety +
+                                      Data->P[plr].Manned[hold].Damage);
                     draw_string(0, 0, "%");
-                    // draw_string(144+i*111,116+14*k,"%");
                     ++k;
                 }
 
@@ -354,13 +351,9 @@ void MisAnn(char plr, char pad)
                     display::graphics.setForegroundColor(11);
                     draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                     Data->P[plr].Misc[hold].Damage != 0 ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment, Nikakd, 10/8/10
-                    snprintf(&Digit[0], sizeof(Digit), "%d",
-                             Data->P[plr].Misc[hold].Safety +
-                             Data->P[plr].Misc[hold].Damage);
-                    draw_string(0, 0, &Digit[0]);
+                    draw_number(0, 0, Data->P[plr].Misc[hold].Safety +
+                                      Data->P[plr].Misc[hold].Damage);
                     draw_string(0, 0, "%");
-                    // draw_number(0,0,Data->P[plr].Misc[hold].Safety);
-                    //    draw_string(144+i*111,116+14*k,"%");
                     ++k;
                 }
 
@@ -375,13 +368,9 @@ void MisAnn(char plr, char pad)
                     display::graphics.setForegroundColor(11);
                     draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                     Data->P[plr].Manned[hold].Damage != 0 ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment, Nikakd, 10/8/10
-                    snprintf(&Digit[0], sizeof(Digit), "%d",
-                             Data->P[plr].Manned[hold].Safety +
-                             Data->P[plr].Manned[hold].Damage);
-                    draw_string(0, 0, &Digit[0]);
+                    draw_number(0, 0, Data->P[plr].Manned[hold].Safety +
+                                      Data->P[plr].Manned[hold].Damage);
                     draw_string(0, 0, "%");
-                    //draw_number(0,0,Data->P[plr].Manned[hold].Safety);
-                    //draw_string(144+i*111,116+14*k,"%");
                     ++k;
                 }
 
@@ -397,13 +386,9 @@ void MisAnn(char plr, char pad)
                         display::graphics.setForegroundColor(11);
                         draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                         Data->P[plr].Probe[hold].Damage != 0 ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment, Nikakd, 10/8/10
-                        snprintf(&Digit[0], sizeof(Digit), "%d",
-                                 Data->P[plr].Probe[hold].Safety +
-                                 Data->P[plr].Probe[hold].Damage);
-                        draw_string(0, 0, &Digit[0]);
+                        draw_number(0 ,0, Data->P[plr].Probe[hold].Safety +
+                                          Data->P[plr].Probe[hold].Damage);
                         draw_string(0, 0, "%");
-                        //draw_number(0,0,Data->P[plr].Probe[hold].Safety);
-                        //draw_string(144+i*111,116+14*k,"%");
                         ++k;
                     } else if (hold == 4) {
                         display::graphics.setForegroundColor(7);
@@ -413,13 +398,9 @@ void MisAnn(char plr, char pad)
                         display::graphics.setForegroundColor(11);
                         draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                         Data->P[plr].Misc[hold].Damage != 0 ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment, Nikakd, 10/8/10
-                        snprintf(&Digit[0], sizeof(Digit), "%d",
-                                 Data->P[plr].Misc[hold].Safety +
-                                 Data->P[plr].Misc[hold].Damage);
-                        draw_string(0, 0, &Digit[0]);
+                        draw_number(0, 0, Data->P[plr].Misc[hold].Safety +
+                                          Data->P[plr].Misc[hold].Damage);
                         draw_string(0, 0, "%");
-                        //draw_number(0,0,Data->P[plr].Misc[hold].Safety);
-                        //draw_string(144+i*111,116+14*k,"%");
                         ++k;
                     }
                 }
@@ -436,13 +417,9 @@ void MisAnn(char plr, char pad)
                         display::graphics.setForegroundColor(11);
                         draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                         Data->P[plr].Rocket[hold - 1].Damage != 0 ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment, Nikakd, 10/8/10
-                        snprintf(&Digit[0], sizeof(Digit), "%d",
-                                 Data->P[plr].Rocket[hold - 1].Safety +
-                                 Data->P[plr].Rocket[hold - 1].Damage);
-                        draw_string(0, 0, &Digit[0]);
+                        draw_number(0, 0, Data->P[plr].Rocket[hold - 1].Safety +
+                                          Data->P[plr].Rocket[hold - 1].Damage);
                         draw_string(0, 0, "%");
-                        //draw_number(0,0,Data->P[plr].Rocket[hold-1].Safety);
-                        //draw_string(144+i*111,116+14*k,"%");
                         ++k;
                     } else {
                         display::graphics.setForegroundColor(7);
@@ -453,11 +430,8 @@ void MisAnn(char plr, char pad)
                         display::graphics.setForegroundColor(11);
                         draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
                         (Data->P[plr].Rocket[hold - 5].Damage != 0 || Data->P[plr].Rocket[ROCKET_HW_BOOSTERS].Damage != 0) ? display::graphics.setForegroundColor(9) : display::graphics.setForegroundColor(1); //Damaged Equipment && Booster's Safety Mod, Nikakd, 10/8/10
-                        snprintf(&Digit[0], sizeof(Digit), "%d", RocketBoosterSafety(Data->P[plr].Rocket[hold - 5].Safety + Data->P[plr].Rocket[hold - 5].Damage, Data->P[plr].Rocket[ROCKET_HW_BOOSTERS].Safety + Data->P[plr].Rocket[ROCKET_HW_BOOSTERS].Damage));
-                        draw_string(0, 0, &Digit[0]);
+                        draw_number(0, 0, RocketBoosterSafety(Data->P[plr].Rocket[hold - 5].Safety + Data->P[plr].Rocket[hold - 5].Damage, Data->P[plr].Rocket[ROCKET_HW_BOOSTERS].Safety + Data->P[plr].Rocket[ROCKET_HW_BOOSTERS].Damage));
                         draw_string(0, 0, "%");
-                        // draw_number(0,0,(Data->P[plr].Rocket[hold-5].Safety+Data->P[plr].Rocket[ROCKET_HW_BOOSTERS].Safety)/2);
-                        // draw_string(144+i*111,116+14*k,"%");
                         ++k;
                     }
                 }
@@ -471,7 +445,6 @@ void MisAnn(char plr, char pad)
     }
 
     FadeIn(2, 10, 0, 0);
-
 
     WaitForMouseUp();
 

--- a/src/game/records.cpp
+++ b/src/game/records.cpp
@@ -396,10 +396,8 @@ void ForEnd(char *pos, char *pos2)
 
 void Drec(char *pos, char *pos2, char mde)
 {
-    char i, j = 0, Digit[10];
+    char i, j = 0;
 
-
-    memset(Digit, 0x00, sizeof(Digit));
     display::graphics.setForegroundColor(1);
     draw_number(12, 42, 1);
     draw_number(12, 66, 2);
@@ -499,9 +497,7 @@ void Drec(char *pos, char *pos2, char mde)
             display::graphics.setForegroundColor(1);
             draw_string(0, 0, Months[rec[*pos2][i].month]);
             draw_string(0, 0, " ");
-            snprintf(&Digit[0], sizeof(Digit), "%d",
-                     rec[*pos2][i].yr + 1900);
-            draw_string(0, 0, &Digit[0]);
+            draw_number(0, 0, rec[*pos2][i].yr + 1900);
 
             if (*pos2 == 29) {
                 display::graphics.setForegroundColor(6);
@@ -564,9 +560,7 @@ void Drec(char *pos, char *pos2, char mde)
                 display::graphics.setForegroundColor(1);
                 draw_string(0, 0, Months[rec[*pos2][i].month]);
                 draw_string(0, 0, " ");
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].yr + 1900);
-                draw_string(0, 0, &Digit[0]);
+                draw_number(0, 0, rec[*pos2][i].yr + 1900);
                 break;
 
             case 35:
@@ -574,9 +568,7 @@ void Drec(char *pos, char *pos2, char mde)
                 display::graphics.setForegroundColor(6);
                 draw_string(143, 48 + (i * 24), "MISSIONS: ");
                 display::graphics.setForegroundColor(1);
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].tag);
-                draw_string(0, 0, &Digit[0]);
+                draw_number(0, 0, rec[*pos2][i].tag);
                 break;
 
             case 37:
@@ -584,9 +576,7 @@ void Drec(char *pos, char *pos2, char mde)
                 display::graphics.setForegroundColor(6);
                 draw_string(143, 48 + (i * 24), "PRESTIGE: ");
                 display::graphics.setForegroundColor(1);
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].tag);
-                draw_string(0, 0, &Digit[0]);
+                draw_number(0, 0, rec[*pos2][i].tag);
                 break;
 
             case 39:
@@ -594,18 +584,14 @@ void Drec(char *pos, char *pos2, char mde)
                 display::graphics.setForegroundColor(6);
                 draw_string(143, 48 + (i * 24), "DAYS: ");
                 display::graphics.setForegroundColor(1);
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].tag);
-                draw_string(0, 0, &Digit[0]);
+                draw_number(0, 0, rec[*pos2][i].tag);
                 break;
 
             case 41:
                 display::graphics.setForegroundColor(6);
                 draw_string(143, 48 + (i * 24), "SEASONS: ");
                 display::graphics.setForegroundColor(1);
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].tag);
-                draw_string(0, 0, &Digit[0]);
+                draw_number(0, 0, rec[*pos2][i].tag);
                 break;
 
             default:
@@ -625,13 +611,9 @@ void Drec(char *pos, char *pos2, char mde)
                 display::graphics.setForegroundColor(6);
                 draw_string(143, 48 + (i * 24), "PRESTIGE: ");
                 display::graphics.setForegroundColor(1);
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].tag);
-                draw_string(0, 0, &Digit[0]);
+                draw_number(0, 0, rec[*pos2][i].tag);
             } else {
-                snprintf(&Digit[0], sizeof(Digit), "%d",
-                         rec[*pos2][i].tag);
-                draw_string(101, 38 + (i * 24), &Digit[0]);
+                draw_number(101, 38 + (i * 24), rec[*pos2][i].tag);
 
                 switch (*pos2) {
                 case 22:


### PR DESCRIPTION
Replace conversions of integer values to char[] for printing to screen.
Use of the basic draw_number function is preferable to conversion via
snprintf.