### PR TITLE
Fix docking safety increase bug in PBEM games

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -1196,12 +1196,15 @@ int U_AllotPrest(char plr, char mis)
 
     } // if
 
-    if (Check_Dock(2) == 2) {
-        Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety += 10;
-        Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety = MIN(Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety, Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].MaxSafety);
-    } else if (Check_Dock(2) == 1) {
-        Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety += 5;
-        Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety = MIN(Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety, Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].MaxSafety);
+    // Don't increase docking safety twice in mail games
+    if (!(MAIL == 1 && plr == 0)) {
+        if (Check_Dock(2) == 2) {
+            Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety += 10;
+            Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety = MIN(Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety, Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].MaxSafety);
+        } else if (Check_Dock(2) == 1) {
+            Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety += 5;
+            Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety = MIN(Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety, Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].MaxSafety);
+        }
     }
 
     return total + negs;


### PR DESCRIPTION
Fixes a bug in PBEM games that led to docking safety being increased twice for unmanned U.S. missions. (Manned missions were already being treated correctly.)