### PR TITLE
Fixed PBEM endgame issues

### DIFF
--- a/src/game/admin.h
+++ b/src/game/admin.h
@@ -1,6 +1,8 @@
 #ifndef ADMIN_H
 #define ADMIN_H
 
+#include <cstdint>
+
 void Admin(char plr);
 void CacheCrewFile();
 int32_t EndOfTurnSave(char *inData, int dataLen);  // Create ENDTURN.TMP

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -603,6 +603,12 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
                         return;
                     }
 
+                    if (Data->Year == 77 && Data->Season == 1 && Data->Prestige[Prestige_MannedLunarLanding].Place == -1 && newTurn == false) { // Nobody won
+                        SpecialEnd();
+                        FadeOut(2, 10, 0, 0);
+                        return;
+                    }
+
                     PlayAllFirsts(MAIL_OPPONENT);
                     ShowPrestigeResults(MAIL);
                 }
@@ -687,16 +693,13 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
                             PlayAllFirsts(Order[i].plr);
                         }
 
-                        if (MAIL != 0 && Data->Prestige[Prestige_MannedLunarLanding].Place != -1) {
-                            UpdateRecords(1);
-                            NewEnd(Data->Prestige[Prestige_MannedLunarLanding].Place, Order[i].loc);
-
-                            if (MAIL == 1) { // Hand back to the U.S. side
-                                MAIL = 0;
-                                MailSave();
+                        if (Data->Prestige[Prestige_MannedLunarLanding].Place != -1) {
+                            if (MAIL != 0) {
+                                UpdateRecords(1);
+                                NewEnd(Data->Prestige[Prestige_MannedLunarLanding].Place, Order[i].loc);
                             }
 
-                            FadeOut(2, 10, 0, 0);
+                            MailSwitchPlayer();
                             return;
                         }
 
@@ -710,12 +713,11 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
         }
 
         if (MAIL == 0) { // Hand over to the Soviet side
-            MAIL = 1;
             // Restore mission counter
             Data->P[0].PastMissionCount = old_mission_count;
             // Restore prestige data to the status before the U.S. missions
             memcpy(Data->Prestige, oldPrestige, MAXIMUM_PRESTIGE_NUM * sizeof(struct PrestType));
-            MailSave();
+            MailSwitchPlayer();
             return;
         }
 
@@ -724,7 +726,7 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
         if (Data->Year == 77 && Data->Season == 1 && Data->Prestige[Prestige_MannedLunarLanding].Place == -1) {
             // nobody wins .....
             SpecialEnd();
-            FadeOut(2, 10, 0, 0);
+            MailSwitchPlayer();
             return;
         }
 
@@ -781,8 +783,7 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
         newTurn = true;
 
         if (MAIL == 1) { // Hand back to the U.S. side
-            MAIL = 0;
-            MailSave();
+            MailSwitchPlayer();
             return;
         }
 

--- a/src/game/pbm.cpp
+++ b/src/game/pbm.cpp
@@ -25,8 +25,11 @@
 
 // This file handles play by e-mail.
 
+#include "admin.h"
 #include "data.h"
 #include "game_main.h"
+#include "pace.h"
+#include "pbm.h"
 #include "review.h"
 
 /* Show the prestige results of all the missions perfomed in the
@@ -55,4 +58,18 @@ void ShowPrestigeResults(char plr)
             MAIL = old_mail;
         }
     }
+}
+
+/* Updates the MAIL variable for the next player and saves the current
+ * game. Only fades out if the game is not a PBEM game.
+ */
+void MailSwitchPlayer(void)
+{
+    MAIL = MAIL_NEXT;
+
+    if (MAIL != -1) {
+        MailSave();
+    }
+
+    FadeOut(2, 10, 0, 0);
 }

--- a/src/game/pbm.h
+++ b/src/game/pbm.h
@@ -3,7 +3,9 @@
 
 #define MAIL_OPPONENT (MAIL == -1 ? -1 : MAIL ^ 1)
 #define MAIL_PLAYER (MAIL)
+#define MAIL_NEXT (MAIL == -1 ? -1 : MAIL ^ 1)
 
 void ShowPrestigeResults(char plr);
+void MailSwitchPlayer();
 
 #endif //PBM_H


### PR DESCRIPTION
Fixes two issues with PBEM endgame handling. 1) The no-win scenario is handled correctly now. 2) After a successful U.S. lunar landing, the turn now ends immediately, ignoring any missions scheduled after the lunar landing mission.