### PR TITLE
Fixes LM points not being awarded in case of a-ok failure

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -189,7 +189,8 @@ void Set_LM(char plr, char total)
     int i;
 
     for (i = 0; i < total; i++) {
-        if (Mev[i].loc == 26 && Mev[i].StepInfo == 1) {
+        if (Mev[i].loc == 26
+            && (Mev[i].StepInfo == 1 || Mev[i].StepInfo == 50)) {
             Data->P[plr].LMpts++;
         }
     }


### PR DESCRIPTION
Fixed a bug that led to LM points not being awarded in case of an "all systems go" (i.e., code 0) failure. Closes #441.