### PR TITLE
Award no Prestige when branching to failure

### DIFF
--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -918,17 +918,11 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
         Mev[STEP].StepInfo = 1900 + Mev[STEP].loc;
 
         if (Mev[STEP].fgoto == -1) {  // End of Mission Flag
-            if (Mev[STEP].PComp > 0) {
-                Mev[STEP].PComp = 4;
-            }
-
+            InvalidatePrestige();
             Mev[STEP].trace = 0x7F;  // End of Mission Signal
             FNote = 5;
         } else if (Mev[STEP].fgoto != -2) {  // Alternate Step is other num
-            if (Mev[STEP].PComp > 0) {
-                Mev[STEP].PComp = 4;
-            }
-
+            InvalidatePrestige();
             Mev[STEP].trace = Mev[STEP].fgoto;
         } else {
             Mev[STEP].trace = STEP + 1;
@@ -1091,9 +1085,11 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
             Mev[STEP].StepInfo = 1800 + Mev[STEP].loc;
 
             if (Mev[STEP].fgoto == -1) {
+                InvalidatePrestige();
                 Mev[STEP].trace = 0x7F;
                 FNote = 0;
             } else if (Mev[STEP].fgoto != -2) {
+                InvalidatePrestige();
                 Mev[STEP].trace = Mev[STEP].fgoto;
             } else {
                 Mev[STEP].trace = STEP + 1;
@@ -1162,8 +1158,10 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
         // Used to reduce safety
 
         if (Mev[STEP].fgoto == -1) {
+            InvalidatePrestige();
             Mev[STEP].trace = 0x7F;
         } else if (Mev[STEP].fgoto != -2) {
+            InvalidatePrestige();
             Mev[STEP].trace = Mev[STEP].fgoto;
         } else {
             Mev[STEP].trace = STEP + 1;
@@ -1200,9 +1198,11 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
         }
 
         if (Mev[STEP].fgoto == -1) {
+            InvalidatePrestige();
             Mev[STEP].trace = 0x7F;
             FNote = 7;
         } else if (Mev[STEP].fgoto != -2) {
+            InvalidatePrestige();
             Mev[STEP].trace = Mev[STEP].fgoto;
         } else {
             Mev[STEP].trace = STEP + 1;
@@ -1323,17 +1323,11 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
         if (PROBLEM == 0) {
             if (Mev[STEP].fgoto == -1) {  // End of Mission Flag
-                if (Mev[STEP].PComp > 0) {
-                    Mev[STEP].PComp = 4;
-                }
-
+                InvalidatePrestige();
                 Mev[STEP].trace = 0x7F;  // End of Mission Signal
                 FNote = 5;
             } else if (Mev[STEP].fgoto != -2) {  // Alternate Step is other num
-                if (Mev[STEP].PComp > 0) {
-                    Mev[STEP].PComp = 4;
-                }
-
+                InvalidatePrestige();
                 Mev[STEP].trace = Mev[STEP].fgoto;
             } else {
                 Mev[STEP].trace = STEP + 1;
@@ -1362,4 +1356,14 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
     death = 0;
     return FNote;
+}
+
+/* Set the PComp flag such that prestige is not being awarded for step
+ * failures.
+ */
+void InvalidatePrestige()
+{
+    if (Mev[STEP].PComp > 0) {
+        Mev[STEP].PComp = 4;
+    }
 }


### PR DESCRIPTION
Fixes several issues in which the game awarded Prestige although the relevant step failed. An example is the "ENGINE BURN FAILURE, CRAFT OUT OF CONTROL." failure (code 26) mentioned in #332, which led to the Manned Orbital prestige being awarded. This commit invalidates any steps for Prestige evaluation in case of a branch to failure (i.e., code 4, 18, 23, and 26).