### PR TITLE
Adds InvalidPrestige prototype.

### DIFF
--- a/src/game/admin.h
+++ b/src/game/admin.h
@@ -1,7 +1,7 @@
 #ifndef ADMIN_H
 #define ADMIN_H
 
-#include <cstdint>
+#include <stdint.h>
 
 void Admin(char plr);
 void CacheCrewFile();

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -67,6 +67,7 @@ int MCGraph(char plr, int lc, int safety, int val, char prob);
 void F_KillCrew(char mode, struct Astros *Victim);
 void F_IRCrew(char mode, struct Astros *Guy);
 int FailEval(char plr, int type, char *text, int val, int xtra);
+void InvalidatePrestige();
 
 /**
  * Load the failure state information explaining a mission step


### PR DESCRIPTION
Fixes some compiler issues. Adds a prototype for the InvalidPrestige function in mis_m.cpp. Also converts admin.h to C++98 compliance, since RIS doesn't direct g++ to use the C++98 flag..