### PR TITLE
Add RomanNumeral function

### DIFF
--- a/src/game/endgame.cpp
+++ b/src/game/endgame.cpp
@@ -184,7 +184,7 @@ void EndGame(char win, char pad)
             prog = Data->P[win].History[Data->Prestige[Prestige_MannedLunarLanding].Index].Hard[i][0] + 1;
             strcpy(capName, &Data->P[win].Manned[prog - 1].Name[0]);
             strcat(capName, " ");
-            strcat(capName, Nums[Data->P[win].Manned[prog - 1].Used]);
+            strncat(capName, RomanNumeral(Data->P[win].Manned[prog - 1].Used).c_str(), 8);
         }
     }
 
@@ -704,7 +704,7 @@ void FakeWin(char win)
     display::graphics.setForegroundColor(8);
     draw_string(0, 0, &Data->P[win].Manned[prog - 1].Name[0]);
     draw_string(0, 0, " ");
-    draw_string(0, 0, &Nums[brandom(15) + 1][0]);
+    draw_string(0, 0, RomanNumeral(brandom(15) + 1).c_str());
     display::graphics.setForegroundColor(6);
     draw_string(0, 0, "  -  ");
     display::graphics.setForegroundColor(8);;

--- a/src/game/museum.cpp
+++ b/src/game/museum.cpp
@@ -26,11 +26,12 @@
 
 // This file handles the Museum and some of its subsections: Space History, Prestige Summary, and Astronaut History
 
+#include "museum.h"
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/palettized_surface.h"
 
-#include "museum.h"
 #include "Buzz_inc.h"
 #include "draw.h"
 #include "hardef.h"
@@ -346,6 +347,7 @@ void ShowPrest(char plr)
             ForOne(plr, &pos, &pos2);
             ForOne(plr, &pos, &pos2);
         }
+
         if (key == K_PGUP) {
             BackOne(plr, &pos, &pos2);
             BackOne(plr, &pos, &pos2);
@@ -357,6 +359,7 @@ void ShowPrest(char plr)
             BackOne(plr, &pos, &pos2);
             BackOne(plr, &pos, &pos2);
         }
+
         if (key == K_END) {
             ForEnd(plr, &pos, &pos2);
         }
@@ -1183,11 +1186,13 @@ void DisplAst(char plr, char *where, char *where2, display::LegacySurface *vhptr
     draw_number(214, 78, abuf[*where].Missions);
     draw_number(217, 89, abuf[*where].Prestige);
     draw_number(253, 149, abuf[*where].Days);
+
     if (abuf[*where].Days == 1) {
         draw_string(0, 0, " DAY");
     } else {
         draw_string(0, 0, " DAYS");
     }
+
     draw_number(253, 107, abuf[*where].Cap);
     draw_number(227, 115, abuf[*where].LM);
     draw_number(204, 123, abuf[*where].EVA);
@@ -1209,7 +1214,7 @@ void DisplAst(char plr, char *where, char *where2, display::LegacySurface *vhptr
 
     draw_string(165, 39, Ast_Name);  // Displays name of astronaut/cosmonaut
     display::graphics.setForegroundColor(11);
-    strcat(temp, Nums[abuf[*where].Group]);
+    strncat(temp, RomanNumeral(abuf[*where].Group + 1).c_str(), 4);
     draw_string(165, 49, temp);
     display::graphics.setForegroundColor(12);
     draw_number(225, 169, *where + 1);

--- a/src/game/start.cpp
+++ b/src/game/start.cpp
@@ -25,21 +25,18 @@
 
 // This file handles start-of-turn events: adjusting 'naut morale, etc.
 
-#include <assert.h>
-
 #include "start.h"
-#include "astros.h"
-#include "pace.h"
-#include "Buzz_inc.h"
-#include "options.h"
-#include "prest.h"
-#include "game_main.h"
 
-char Nums[30][7] = {"I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X",
-                    "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX",
-                    "XX", "XXI", "XXII", "XXIII", "XXIV", "XXV", "XXVI", "XXVII",
-                    "XXVIII", "XXIX", "XXX"
-                   };
+#include <cassert>
+#include <stdexcept>
+
+#include "Buzz_inc.h"
+#include "astros.h"
+#include "game_main.h"
+#include "options.h"
+#include "pace.h"
+#include "prest.h"
+
 
 /** \todo This function fills Data->Events, but how it's a mystery... */
 
@@ -287,7 +284,7 @@ void AstroConflictsMod(int player, struct Astros &astro)
 {
     //-2 for each in Jupiter/Minishuttle , -3 in others
     astro.Mood -= ((astro.Assign == 5 || astro.Assign == 4) ? 2 : 3) *
-        CrewConflicts(player, astro);
+                  CrewConflicts(player, astro);
 }
 
 
@@ -633,6 +630,32 @@ int CrewConflicts(const int player, const struct Astros &astro)
 }
 
 
+/**
+ * Represents a value in Roman numerals.
+ *
+ * This uses Standard Form notation to represent an value via
+ * Roman Numerals, suitable for any number 0 to 3999.
+ * The maximum length of the returned string is 15.
+ */
+std::string RomanNumeral(unsigned int value)
+{
+    std::string thousands[] = { "", "M", "MM", "MMM" };
+    std::string hundreds[] =
+    { "", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM" };
+    std::string tens[] =
+    { "", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC" };
+    std::string ones[] =
+    { "", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX" };
+
+    if (value > 3999) {
+        throw std::runtime_error("Cannot craft a Roman Numeral > 3999");
+    }
+
+    return thousands[value / 1000] + hundreds[(value % 1000) / 100] +
+           tens[(value % 100) / 10] + ones[value % 10];
+}
+
+
 void Update(void)
 {
     int i, j, k;
@@ -667,14 +690,14 @@ void Update(void)
                 Data->P[j].Mission[i].Patch = -1;
                 strcpy(&tName[0], &Data->P[j].Probe[PROBE_HW_ORBITAL].Name[0]);
                 strcat(&tName[0], " ");
-                strcat(&tName[0], &Nums[(Data->P[j].Probe[PROBE_HW_ORBITAL].Code) % 30][0]);
+                strcat(&tName[0], RomanNumeral(Data->P[j].Probe[PROBE_HW_ORBITAL].Code).c_str());
                 strcpy(&Data->P[j].Mission[i].Name[0], &tName[0]);  // copy into struct
                 Data->P[j].Probe[PROBE_HW_ORBITAL].Code++;  // Increase Planned Mission Count
             } else if (Data->P[j].Mission[i].MissionCode == Mission_Lunar_Probe) {
                 Data->P[j].Mission[i].Patch = -1;
                 strcpy(&tName[0], &Data->P[j].Probe[PROBE_HW_LUNAR].Name[0]);
                 strcat(&tName[0], " ");
-                strcat(&tName[0], &Nums[(Data->P[j].Probe[PROBE_HW_LUNAR].Code) % 30][0]);
+                strcat(&tName[0], RomanNumeral(Data->P[j].Probe[PROBE_HW_LUNAR].Code).c_str());
                 strcpy(&Data->P[j].Mission[i].Name[0], &tName[0]);  // copy into struct
                 Data->P[j].Probe[PROBE_HW_LUNAR].Code++;  // Increase Planned Mission Count
             } else if (Data->P[j].Mission[i].MissionCode == Mission_LunarFlyby ||
@@ -683,7 +706,7 @@ void Update(void)
                 Data->P[j].Mission[i].Patch = -1;
                 strcpy(&tName[0], &Data->P[j].Probe[PROBE_HW_INTERPLANETARY].Name[0]);
                 strcat(&tName[0], " ");
-                strcat(&tName[0], &Nums[Data->P[j].Probe[PROBE_HW_INTERPLANETARY].Code][0]);
+                strcat(&tName[0], RomanNumeral(Data->P[j].Probe[PROBE_HW_INTERPLANETARY].Code).c_str());
                 strcpy(&Data->P[j].Mission[i].Name[0], &tName[0]);  // copy into struct
                 Data->P[j].Probe[PROBE_HW_INTERPLANETARY].Code++;  // Increase Planned Mission Count
             } else if (Data->P[j].Mission[i].MissionCode > 0) {
@@ -692,7 +715,7 @@ void Update(void)
                     Data->P[j].Mission[i].Patch = Data->P[j].Manned[k].Code % 10;
                     strcpy(&tName[0], &Data->P[j].Manned[k].Name[0]);
                     strcat(&tName[0], " ");
-                    strcat(&tName[0], &Nums[Data->P[j].Manned[k].Code][0]);
+                    strcat(&tName[0], RomanNumeral(Data->P[j].Manned[k].Code).c_str());
                     strcpy(&Data->P[j].Mission[i].Name[0], &tName[0]);  // copy into struct
                     Data->P[j].Manned[k].Code++;  // Increase Planned Mission Count
                 } else {
@@ -701,14 +724,14 @@ void Update(void)
                         Data->P[j].Mission[i].Patch = Data->P[j].Manned[k].Code % 10;
                         strcpy(&tName[0], &Data->P[j].Manned[k].Name[0]);
                         strcat(&tName[0], " ");
-                        strcat(&tName[0], &Nums[Data->P[j].Manned[k].Code][0]);
+                        strcat(&tName[0], RomanNumeral(Data->P[j].Manned[k].Code).c_str());
                         strcpy(&Data->P[j].Mission[i].Name[0], &tName[0]);  // copy into struct
                     } else {
                         k = Data->P[j].Mission[i].Prog - 1;
                         Data->P[j].Mission[i].Patch = Data->P[j].Manned[k].Code % 10;
                         strcpy(&tName[0], &Data->P[j].Manned[k].Name[0]);
                         strcat(&tName[0], " ");
-                        strcat(&tName[0], &Nums[Data->P[j].Manned[k].Code][0]);
+                        strcat(&tName[0], RomanNumeral(Data->P[j].Manned[k].Code).c_str());
                         strcpy(&Data->P[j].Mission[i].Name[0], &tName[0]);  // copy into struct
                         Data->P[j].Manned[k].Code++;  // Increase Planned Mission Count
                     }
@@ -860,14 +883,14 @@ void UpdAll(char side)
             Data->P[side].Mission[i].Patch = -1;
             strcpy(&tName[0], &Data->P[side].Probe[PROBE_HW_ORBITAL].Name[0]);
             strcat(&tName[0], " ");
-            strcat(&tName[0], &Nums[(Data->P[side].Probe[PROBE_HW_ORBITAL].Code) % 30][0]);
+            strcat(&tName[0], RomanNumeral(Data->P[side].Probe[PROBE_HW_ORBITAL].Code).c_str());
             strcpy(&Data->P[side].Mission[i].Name[0], &tName[0]);  // copy into struct
             Data->P[side].Probe[PROBE_HW_ORBITAL].Code++;  // Increase Planned Mission Count
         } else if (Data->P[side].Mission[i].MissionCode == Mission_Lunar_Probe) {
             Data->P[side].Mission[i].Patch = -1;
             strcpy(&tName[0], &Data->P[side].Probe[PROBE_HW_LUNAR].Name[0]);
             strcat(&tName[0], " ");
-            strcat(&tName[0], &Nums[(Data->P[side].Probe[PROBE_HW_LUNAR].Code) % 30][0]);
+            strcat(&tName[0], RomanNumeral(Data->P[side].Probe[PROBE_HW_LUNAR].Code).c_str());
             strcpy(&Data->P[side].Mission[i].Name[0], &tName[0]);  // copy into struct
             Data->P[side].Probe[PROBE_HW_LUNAR].Code++;  // Increase Planned Mission Count
         } else if (Data->P[side].Mission[i].MissionCode == Mission_LunarFlyby ||
@@ -876,7 +899,7 @@ void UpdAll(char side)
             Data->P[side].Mission[i].Patch = -1;
             strcpy(&tName[0], &Data->P[side].Probe[PROBE_HW_INTERPLANETARY].Name[0]);
             strcat(&tName[0], " ");
-            strcat(&tName[0], &Nums[Data->P[side].Probe[PROBE_HW_INTERPLANETARY].Code][0]);
+            strcat(&tName[0], RomanNumeral(Data->P[side].Probe[PROBE_HW_INTERPLANETARY].Code).c_str());
             strcpy(&Data->P[side].Mission[i].Name[0], &tName[0]);  // copy into struct
             Data->P[side].Probe[PROBE_HW_INTERPLANETARY].Code++;  // Increase Planned Mission Count
         } else if (Data->P[side].Mission[i].MissionCode > 0) {
@@ -885,7 +908,7 @@ void UpdAll(char side)
                 Data->P[side].Mission[i].Patch = Data->P[side].Manned[k].Code % 10;
                 strcpy(&tName[0], &Data->P[side].Manned[k].Name[0]);
                 strcat(&tName[0], " ");
-                strcat(&tName[0], &Nums[Data->P[side].Manned[k].Code][0]);
+                strcat(&tName[0], RomanNumeral(Data->P[side].Manned[k].Code).c_str());
                 strcpy(&Data->P[side].Mission[i].Name[0], &tName[0]);  // copy into struct
                 Data->P[side].Manned[k].Code++;  // Increase Planned Mission Count
             } else {
@@ -894,14 +917,14 @@ void UpdAll(char side)
                     Data->P[side].Mission[i].Patch = Data->P[side].Manned[k].Code % 10;
                     strcpy(&tName[0], &Data->P[side].Manned[k].Name[0]);
                     strcat(&tName[0], " ");
-                    strcat(&tName[0], &Nums[Data->P[side].Manned[k].Code][0]);
+                    strcat(&tName[0], RomanNumeral(Data->P[side].Manned[k].Code).c_str());
                     strcpy(&Data->P[side].Mission[i].Name[0], &tName[0]);  // copy into struct
                 } else {
                     k = Data->P[side].Mission[i].Prog - 1;
                     Data->P[side].Mission[i].Patch = Data->P[side].Manned[k].Code % 10;
                     strcpy(&tName[0], &Data->P[side].Manned[k].Name[0]);
                     strcat(&tName[0], " ");
-                    strcat(&tName[0], &Nums[Data->P[side].Manned[k].Code][0]);
+                    strcat(&tName[0], RomanNumeral(Data->P[side].Manned[k].Code).c_str());
                     strcpy(&Data->P[side].Mission[i].Name[0], &tName[0]); // copy into struct
                     Data->P[side].Manned[k].Code++;  // Increase Planned Mission Count
                 }

--- a/src/game/start.h
+++ b/src/game/start.h
@@ -1,9 +1,12 @@
 #ifndef START_H
 #define START_H
 
-void Update(void);
-void InitializeEvents(void);
+#include <string>
 
-extern char Nums[30][7];
+
+void InitializeEvents(void);
+std::string RomanNumeral(unsigned int value);
+void Update(void);
+
 
 #endif // START_H


### PR DESCRIPTION
Replace the char[] literal array Nums with a RomanNumeral function
capable of handling all values from 0-3999. This solves array overflow
problems experienced with Nums.