### PR TITLE
Adds PhotoRecon to mission hardware global MH

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -811,10 +811,6 @@ void MissionSetup(char plr, char mis)
                 case Mission_EVA:  // EVA
                     eq = &Data->P[plr].Misc[MISC_HW_EVA_SUITS];
                     break;
-
-                case Mission_PhotoRecon:  // Photo Recon
-                    eq = &Data->P[plr].Misc[MISC_HW_PHOTO_RECON];
-                    break;
                 }
 
                 if (eq != NULL) {
@@ -838,10 +834,24 @@ void MissionSetup(char plr, char mis)
                         }
                     }
                 }
-
             } // if t>=0
+
             MH[j][i] = eq;
         } // for (i<7)
+
+        // TODO: This is a backstop against unexpected behavior.
+        // MissionType.Hard[Mission_EVA] is initialized to 0.
+        // However, it ought to be set in the VAB explicitly. As the
+        // VAB _should_ stop any EVA missions from proceeding this
+        // protects against the mission Hard[] field not being
+        // properly initialized until the VAB EVA assignment is
+        // improved.
+        MH[j][Mission_EVA] = &Data->P[plr].Misc[MISC_HW_EVA_SUITS];
+
+        // Photo Recon isn't included in MissionType.Hard - it's
+        // always available.
+        MH[j][Mission_PhotoRecon] =
+            &Data->P[plr].Misc[MISC_HW_PHOTO_RECON];
     } // for (j<2)
 
     if (DMFake == 1) {


### PR DESCRIPTION
Ensures that Photo Recon will be assigned to its slot in a mission's MH
array. This contines a fix begun in commit
117dcf6a702c1095ceb2b66d55959166d2a24bf0.

Commit 117dcf6a stops MissionSetup from checking outside the bounds of
the MissionType.Hard array. Because the array does not include a slot
for Photo Recon, it was no longer being assigned to the MH global
variable, whereas previously the array overrun had the side effect of
doing so. This commit automatically assigns Photo Recon to the
appropriate MH slot for every mission, as Photo Recon is always
available.

EVA suits are also automatically assigned to a mission, because the VAB
does not explicitly set MissionType.Hard[Mission_EVA] when assigning
mission hardware, but does guarantee that hardware cannot be assigned
for an EVA mission if the EVA program isn't started.