### PR TITLE
Kill the correct crew on LM mission failure steps

### DIFF
--- a/src/game/hardware.cpp
+++ b/src/game/hardware.cpp
@@ -15,13 +15,106 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include "hardware.h"
+
 #include <cassert>
 #include <stdexcept>
 
-#include "Buzz_inc.h"
-#include "data.h"
 #include "game_main.h"
+#include "macros.h"
 #include "options.h"
+
+
+/**
+ * Check the crew capacity for a Capsule/Minishuttle or Lunar Module.
+ *
+ * \param program  a Manned hardware program.
+ * \return  number of crew allowed/required (0 if unmanned).
+ */
+int CrewSize(const Equipment &program)
+{
+    MissionHardwareType type = HardwareType(program);
+
+    if (type != Mission_Capsule && type != Mission_LM) {
+        return 0;
+    }
+
+    int mannedIndex = int(program.ID[1] - '0');
+
+    switch (mannedIndex) {
+    case MANNED_HW_ONE_MAN_CAPSULE:
+        return 1;
+
+    case MANNED_HW_TWO_MAN_CAPSULE:
+        return 2;
+
+    case MANNED_HW_THREE_MAN_CAPSULE:
+    case MANNED_HW_MINISHUTTLE:
+        return 3;
+
+    case MANNED_HW_FOUR_MAN_CAPSULE:
+        return 4;
+
+    case MANNED_HW_TWO_MAN_MODULE:
+        return 2;
+
+    case MANNED_HW_ONE_MAN_MODULE:
+        return 1;
+
+    default:
+        return 0;
+    }
+
+    return 0;
+}
+
+
+/**
+ * TODO: Describe.
+ *
+ * If the argument is not a recognized hardware program, the
+ * result is undefined.
+ */
+MissionHardwareType HardwareType(const Equipment &program)
+{
+    switch (program.ID[0]) {
+    case 'P':
+        return Mission_Probe_DM;
+
+    case 'C':
+        return (program.ID[1] <= MANNED_HW_FOUR_MAN_CAPSULE)
+               ? Mission_Capsule : Mission_LM;
+
+    case 'R':
+        return (program.ID[1] != ROCKET_HW_BOOSTERS)
+               ? Mission_PrimaryBooster : Mission_SecondaryBooster;
+
+    case 'M':
+        if (program.ID[1] <= MISC_HW_KICKER_C) {
+            return Mission_Kicker;
+        } else if (program.ID[1] == MISC_HW_EVA_SUITS) {
+            return Mission_EVA;
+        } else if (program.ID[1] == MISC_HW_DOCKING_MODULE) {
+            return Mission_Probe_DM;
+        } else if (program.ID[1] == MISC_HW_PHOTO_RECON) {
+            return Mission_PhotoRecon;
+        } else {
+            throw std::invalid_argument(
+                "Error in function HardwareType: "
+                "argument program is not recognized Misc hardware");
+        }
+
+    default:
+        throw std::invalid_argument(
+            "Error in function HardwareType: "
+            "program's hardware index is not recognized.");
+        break;
+    }
+
+    throw std::invalid_argument(
+        "Error in function HardwareType: "
+        "program's hardware index is not recognized.");
+}
 
 
 /**

--- a/src/game/hardware.h
+++ b/src/game/hardware.h
@@ -1,8 +1,11 @@
 #ifndef HARDWARE_H
 #define HARDWARE_H
 
+#include "data.h"
 
+int CrewSize(const Equipment &program);
 Equipment &HardwareProgram(int player, int type, int program);
+MissionHardwareType HardwareType(const Equipment &program);
 int RocketBoosterSafety(int safetyRocket, int safetyBooster);
 
 

--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -221,18 +221,9 @@ int Launch(char plr, char mis)
             break;  // Last in LM
 
         case 3:
-
-            // LM is always on first mission part!!! :: makes things easier
-            if (MH[0][Mission_LM] && MH[0][Mission_LM]->ID[1] == 0x35) {
-                CAP[i] = 0;
-                LM[i] = 1;
-                DOC[i] = EVA[i] = 2;
-            } else {
-                CAP[i] = 0;
-                LM[i] = EVA[i] = 1;
-                DOC[i] = 2;
-            }
-
+            CAP[i] = 0;
+            LM[i] = EVA[i] = 1;
+            DOC[i] = 2;
             break;
 
         case 4:


### PR DESCRIPTION
Fix an incorrect Lunar Module crew assignment when handling mission step
failures. Code 31 step failures kill the entire LM crew, previously
implemented as the LM pilot and EVA specialist. However, the lunar
landing code DrawMoonSelection() uses the LM pilot, plus the Command
pilot for 2-man LMs. Keeping to history, the LM will be staffed by the
Mission Commander (in-game the Command pilot) and LM pilot.

Using the Mission Commander and LM pilot removes a hack by which the
Capsule Pilot (aka Docking Specialist) was set as EVA specialist for
missions using the 2-man LM. This hack meant the wrong crew member would
perform spacewalks on LM Test EVA missions.

The Mission Commander dying on the LM introduces a new bug whereby their
CA skill is added to subsequent Capsule tests, but _that is entirely
consistent with current (bugged) mission death behavior_.