### PR TITLE
Fix uninitialized mission safety for Photo Recon

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -853,19 +853,13 @@ void MissionSetup(char plr, char mis)
             MH[j][i] = eq;
         } // for (i<7)
 
-        // TODO: This is a backstop against unexpected behavior.
-        // MissionType.Hard[Mission_EVA] is initialized to 0.
-        // However, it ought to be set in the VAB explicitly. As the
-        // VAB _should_ stop any EVA missions from proceeding this
-        // protects against the mission Hard[] field not being
-        // properly initialized until the VAB EVA assignment is
-        // improved.
-        MH[j][Mission_EVA] = &Data->P[plr].Misc[MISC_HW_EVA_SUITS];
-
         // Photo Recon isn't included in MissionType.Hard - it's
         // always available.
         MH[j][Mission_PhotoRecon] =
             &Data->P[plr].Misc[MISC_HW_PHOTO_RECON];
+        // Photo Recon should never be damaged.
+        MH[j][Mission_PhotoRecon]->MisSaf =
+            MH[j][Mission_PhotoRecon]->Safety;
     } // for (j<2)
 
     if (DMFake == 1) {
@@ -956,6 +950,9 @@ void MissionSetDown(char plr, char mis)
 
 /**
  * Compute and apply safety penalties to mission steps.
+ *
+ * This should only be called after MissionSetup() so the global array
+ * MH[][] will be populated.
  *
  * \param plr  the index of the current player
  * \param mission  the mission plan with configured Days duration.

--- a/src/game/vab.cpp
+++ b/src/game/vab.cpp
@@ -978,6 +978,13 @@ void ReserveHardware(int plr, int pad, int payload, Vehicle &rocket)
         }
     }
 
+    if (IsManned(Data->P[plr].Mission[pad].MissionCode) &&
+        Data->P[plr].Misc[MISC_HW_EVA_SUITS].Num != PROGRAM_NOT_STARTED) {
+        Data->P[plr].Mission[pad].Hard[Mission_EVA] = MISC_HW_EVA_SUITS;
+    } else {
+        Data->P[plr].Mission[pad].Hard[Mission_EVA] = -1;
+    }
+
     rocket.assignTo(pad);
 }
 


### PR DESCRIPTION
Sets the MisSaf field for the Photo Recon when performing Mission Setup.
This continues a bug fix in d2b5c1b5446aa8300bc8d7d90ae9d9032f996b4f.
Fixes #482.

Because the MissionType.Hard array does not include a slot for
Mission_PhotoRecon, Photo Recon was not being properly added to the mission
hardware array (the global MH). Commit d2b5c1b5446 explicitly added
Photo Recon to all missions, but overlooked setting the mission safety
field MisSaf that tests are rolled against. This commit fixes that.

This also sets the MissionType.Hard[Mission_EVA] field in the VAB on
manned missions, so MissionSetup() isn't tacitly relying on the field
being initialized to a default of 0.