### PR TITLE
Show EVA safety on preflight mission display

### DIFF
--- a/src/game/mission_util.cpp
+++ b/src/game/mission_util.cpp
@@ -84,6 +84,18 @@ bool IsDuration(int mission)
 
 
 /**
+ * Checks if the mission contains a spacewalk.
+ *
+ * \param mission  The type per mStr.Index or MissionType.MissionCode.
+ * \return  true if an EVA step is required.
+ */
+bool IsEVA(int mission)
+{
+    return GetMissionPlan(mission).EVA >= 1;
+}
+
+
+/**
  * Checks if the mission has two separate launches.
  *
  * \param mission  The type per mStr.Index or MissionType.MissionCode.

--- a/src/game/mission_util.h
+++ b/src/game/mission_util.h
@@ -7,6 +7,7 @@ const char *GetDurationParens(int duration);
 struct mStr GetMissionPlan(int code);
 bool IsDocking(int mission);
 bool IsDuration(int mission);
+bool IsEVA(int mission);
 bool IsJoint(int mission);
 bool IsLEORegion(int mission);
 bool IsLunarLanding(int mission);

--- a/src/game/newmis.cpp
+++ b/src/game/newmis.cpp
@@ -328,7 +328,7 @@ void MisAnn(char plr, char pad)
             bud = 160;
         }
 
-        for (j = Mission_Capsule; j <= Mission_PrimaryBooster; j++) {
+        for (j = Mission_Capsule; j <= Mission_EVA; j++) {
             hold = Data->P[plr].Mission[pad + i].Hard[j];
 
             switch (j) {
@@ -441,6 +441,28 @@ void MisAnn(char plr, char pad)
                         draw_string(0, 0, "%");
                         ++k;
                     }
+                }
+
+                break;
+
+            case Mission_EVA:
+
+                // EVA suits are added to _all_ manned missions once
+                // developed (for emergencies). Only display if needed.
+                if (hold > -1 &&
+                    IsEVA(Data->P[plr].Mission[pad].MissionCode)) {
+                    display::graphics.setForegroundColor(7);
+                    draw_string(bud, 109 + 14 * k, "EVA: ");
+                    display::graphics.setForegroundColor(1);
+                    draw_string(0, 0, &Data->P[plr].Misc[hold].Name[0]);
+                    display::graphics.setForegroundColor(11);
+                    draw_string(bud, 116 + 14 * k, "SAFETY FACTOR: ");
+                    display::graphics.setForegroundColor(
+                        Data->P[plr].Misc[hold].Damage != 0 ? 9 : 1);
+                    draw_number(0, 0, Data->P[plr].Misc[hold].Safety +
+                                Data->P[plr].Misc[hold].Damage);
+                    draw_string(0, 0, "%");
+                    ++k;
                 }
 
                 break;


### PR DESCRIPTION
Displays the EVA Suit safety values in the list with Rocket, Capsule,
etc. safeties on the last prelaunch go/no-go menu before starting a
mission where a spacewalk is planned.