### PR TITLE
Make game saves the same size on 32bit platform

### DIFF
--- a/src/game/data.h
+++ b/src/game/data.h
@@ -464,7 +464,10 @@ struct MisEval {
     char step;              /**< actual step id number */
     char loc;               /**< Mission Step Name Index */
     uint16_t StepInfo;      /**< ID of step success  1=succ   !1=fail */
-    Equipment *E;           /**< Pointer into equipment */
+    union {
+        Equipment *Ep;      /**< Pointer into equipment, use GetEquipment() */
+        uint64_t Ebits;     /**< keep 64b also on 32b platforms.  */
+	};
     char Prest;             /**< Prestige Step #  (-1 for none) */
     char PComp;             /**< PComp will be set to amt of prest to be awarded. */
     char pad;               /**< pad location  (Index into First Part of MH[x][] */
@@ -849,6 +852,7 @@ BOOST_STATIC_ASSERT(sizeof(MissionType) == 43);
 BOOST_STATIC_ASSERT(sizeof(Astros) == 63);
 BOOST_STATIC_ASSERT(sizeof(PastInfo) == 84);
 BOOST_STATIC_ASSERT(sizeof(BuzzData) == 15520);
+BOOST_STATIC_ASSERT(sizeof(MisEval) == 40);
 BOOST_STATIC_ASSERT(sizeof(Players) == 38866);
 
 #endif // __DATA_H__

--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -315,11 +315,11 @@ int Launch(char plr, char mis)
         for (i = 0; Mev[i].loc != 0x7f; ++i) {
             /* Bugfix -> We need to skip cases when Mev[i].E is NULL */
             /* Same solution as used in mis_m.c (MisCheck):207 */
-            if (!Mev[i].E) {
+            if (!GetEquipment(Mev[i])) {
                 continue;
             }
 
-            avg += Mev[i].E->MisSaf + Mev[i].asf;
+            avg += GetEquipment(Mev[i])->MisSaf + Mev[i].asf;
             temp += 1;
         }
 

--- a/src/game/mc.h
+++ b/src/game/mc.h
@@ -24,4 +24,6 @@ extern char fEarly;
 extern char mcc;
 extern char hero;
 
+Equipment * GetEquipment(const struct MisEval &Mev);
+
 #endif // MC_H

--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -192,6 +192,13 @@ char WhichPart(char plr, int which)
     return val;
 }
 
+Equipment * GetEquipment(const struct MisEval &Mev)
+{
+	Equipment *e = MH[Mev.pad][Mev.Class];
+	assert(e == Mev.Ep);
+	return e;
+}
+
 void MissionSteps(char plr, int mcode, int step, int pad,
                   const struct mStr &mission)
 {
@@ -513,7 +520,7 @@ void MissionSteps(char plr, int mcode, int step, int pad,
         Mev[step].fgoto =
             (mission.Alt[step] == -2) ? step + 1 : mission.Alt[step];
         Mev[step].dgoto = mission.AltD[step];  // death branching (tm)
-        Mev[step].E = MH[pad][Mev[step].Class];
+        Mev[step].Ep = MH[pad][Mev[step].Class]; // FIXME: << this sets E
 
         Mev[step].pad = pad;
 

--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -1067,6 +1067,7 @@ char FailureMode(char plr, int prelim, char *text)
     int i, j, k;
     FILE *fin;
     double last_secs;
+    Equipment *e;
     display::LegacySurface saveScreen(display::graphics.screen()->width(), display::graphics.screen()->height());
 
     FadeOut(2, 10, 0, 0);
@@ -1088,19 +1089,20 @@ char FailureMode(char plr, int prelim, char *text)
 
     display::graphics.setForegroundColor(1);
     MisStep(9, 34, Mev[STEP].loc);
+    e = GetEquipment(Mev[STEP]);
     draw_string(9, 41, "MISSION STEP: ");
     draw_number(0, 0, STEP);
-    draw_string(9, 48, Mev[STEP].E->Name);
+    draw_string(9, 48, e->Name);
     draw_string(0, 0, " CHECK");
 
-    if (strncmp(Mev[STEP].E->Name, "DO", 2) == 0) {
+    if (strncmp(e->Name, "DO", 2) == 0) {
         if (Mev[STEP].loc == 1 || Mev[STEP].loc == 2) {
-            draw_number(9, 55, Mev[STEP].E->MSF);
+            draw_number(9, 55, e->MSF);
         } else {
-            draw_number(9, 55, Mev[STEP].E->MisSaf);
+            draw_number(9, 55, e->MisSaf);
         }
     } else {
-        draw_number(9, 55, Mev[STEP].E->MisSaf);
+        draw_number(9, 55, e->MisSaf);
     }
 
 
@@ -1195,17 +1197,17 @@ char FailureMode(char plr, int prelim, char *text)
     }
 
     if (MANNED[Mev[STEP].pad] == 0) {
-        if (((Mev[STEP].E->ID[1] == 0x35 || Mev[STEP].E->ID[1] == 0x36) && STEP > 5)) {  // if LEMS
+        if (((e->ID[1] == 0x35 || e->ID[1] == 0x36) && STEP > 5)) {  // if LEMS
             GuyDisp(49, 138, MA[1][LM[1]].A);
 
             if (EVA[1] != LM[1]) {
                 GuyDisp(49, 146, MA[1][EVA[1]].A);
             }
-        } else if (strncmp(Mev[STEP].E->ID, "M2", 2) == 0) {
+        } else if (strncmp(e->ID, "M2", 2) == 0) {
             GuyDisp(49, 138, MA[other(Mev[STEP].pad)][0].A);
             GuyDisp(49, 146, MA[other(Mev[STEP].pad)][1].A);
             GuyDisp(182, 138, MA[other(Mev[STEP].pad)][2].A);
-        } else if (strncmp(Mev[STEP].E->ID, "M3", 2) == 0) {  // EVA
+        } else if (strncmp(e->ID, "M3", 2) == 0) {  // EVA
             GuyDisp(49, 138, MA[1][EVA[1]].A);
         } else {
             display::graphics.setForegroundColor(1);
@@ -1282,7 +1284,7 @@ char FailureMode(char plr, int prelim, char *text)
         strcat(Name, "SV");
     }
 
-    strncat(Name, Mev[STEP].E->ID, 2);
+    strncat(Name, e->ID, 2);
 
     if (Mev[STEP].Class == Mission_PhotoRecon) {
         strcpy(&Name[0], "XCAM\0");
@@ -1460,6 +1462,8 @@ int StepAnim(int x, int y, FILE *fin)
 void FirstManOnMoon(char plr, char isAI, char misNum)
 {
     int nautsOnMoon = 0;
+    Equipment *e = GetEquipment(Mev[STEP]);
+
     dayOnMoon = brandom(daysAMonth[Data->P[plr].Mission[Mev[STEP].pad].Month]) + 1;
 
     if (misNum == Mission_Soyuz_LL && plr == 1) {
@@ -1468,17 +1472,17 @@ void FirstManOnMoon(char plr, char isAI, char misNum)
 
 
     //Direct Ascent
-    if (strcmp(Mev[STEP].E->Name, Data->P[plr].Manned[MANNED_HW_FOUR_MAN_CAPSULE].Name) == 0) {
+    if (strcmp(e->Name, Data->P[plr].Manned[MANNED_HW_FOUR_MAN_CAPSULE].Name) == 0) {
         nautsOnMoon = 4;
     }
 
     //2 men LL
-    if (strcmp(Mev[STEP].E->Name, Data->P[plr].Manned[MANNED_HW_TWO_MAN_MODULE].Name) == 0) {
+    if (strcmp(e->Name, Data->P[plr].Manned[MANNED_HW_TWO_MAN_MODULE].Name) == 0) {
         nautsOnMoon = 2;
     }
 
     //1 man LL
-    if (strcmp(Mev[STEP].E->Name, Data->P[plr].Manned[MANNED_HW_ONE_MAN_MODULE].Name) == 0) {
+    if (strcmp(e->Name, Data->P[plr].Manned[MANNED_HW_ONE_MAN_MODULE].Name) == 0) {
         nautsOnMoon = 1;
     }
 
@@ -1506,6 +1510,7 @@ char DrawMoonSelection(char nauts, char plr)
     struct MisAst MX[2][4];
     FILE *fin;
     double last_secs;
+    Equipment *e;
     display::LegacySurface saveScreen(display::graphics.screen()->width(), display::graphics.screen()->height());
 
     memcpy(MX, MA, 8 * sizeof(struct MisAst));
@@ -1545,7 +1550,8 @@ char DrawMoonSelection(char nauts, char plr)
         strcat(Name, "SV");
     }
 
-    strncat(Name, Mev[STEP].E->ID, 2);
+    e = GetEquipment(Mev[STEP]);
+    strncat(Name, e->ID, 2);
 
     if (Mev[STEP].Class == Mission_PhotoRecon) {
         strcpy(&Name[0], "XCAM\0");

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -329,7 +329,7 @@ void MisCheck(char plr, char mpad)
         }
 
         // Necessary to keep code from crashing on bogus mission step
-        while (Mev[STEP].E == NULL) {
+        while (GetEquipment(Mev[STEP]) == NULL) {
             STEP++;
         }
 
@@ -363,7 +363,7 @@ void MisCheck(char plr, char mpad)
 
         // SAFETY FACTOR STUFF
 
-        safety = Mev[STEP].E->MisSaf;
+        safety = GetEquipment(Mev[STEP])->MisSaf;
 
         if ((Mev[STEP].Name[0] == 'A') &&
             MH[Mev[STEP].pad][Mission_SecondaryBooster] != NULL) {
@@ -373,7 +373,7 @@ void MisCheck(char plr, char mpad)
 
         // Duration Hack Part 3 of 3
         if (Mev[STEP].loc == 28 || Mev[STEP].loc == 27) {
-            safety = Mev[STEP].E->MisSaf;  // needs to be for both
+            safety = GetEquipment(Mev[STEP])->MisSaf;  // needs to be for both
 
             // Use average of capsule ratings for Joint duration
             if (InSpace == 2) {
@@ -382,9 +382,9 @@ void MisCheck(char plr, char mpad)
             }
         }
 
-        if (strncmp(Mev[STEP].E->Name, "DO", 2) == 0) {
+        if (strncmp(GetEquipment(Mev[STEP])->Name, "DO", 2) == 0) {
             if (Mev[STEP].loc == 1 || Mev[STEP].loc == 2) {
-                safety = Mev[STEP].E->MSF;
+                safety = GetEquipment(Mev[STEP])->MSF;
             }
         }
 
@@ -395,7 +395,7 @@ void MisCheck(char plr, char mpad)
             safety = 99;
         }
 
-        save = (Mev[STEP].E->SaveCard == 1) ? 1 : 0;
+        save = (GetEquipment(Mev[STEP])->SaveCard == 1) ? 1 : 0;
 
         PROBLEM = val > safety;
 
@@ -413,7 +413,7 @@ void MisCheck(char plr, char mpad)
             }
 
         if (PROBLEM && save == 1) {  // Failure Saved
-            Mev[STEP].E->SaveCard--;    // Deduct SCard
+            GetEquipment(Mev[STEP])->SaveCard--;    // Deduct SCard
             PROBLEM = 0;  // Fix problem
         }
 
@@ -421,7 +421,7 @@ void MisCheck(char plr, char mpad)
         // Fix wrong anim thing for the Jt Durations
         if (Mev[STEP].loc == 28 || Mev[STEP].loc == 27) {
             strcpy(Mev[STEP].Name, (plr == 0) ? "_BUSC0\0" : "_BSVC0");
-            Mev[STEP].Name[5] = Mev[STEP].E->ID[1];
+            Mev[STEP].Name[5] = GetEquipment(Mev[STEP])->ID[1];
         }
 
         if (PROBLEM == 1) {  // Step Problem
@@ -507,10 +507,10 @@ void MisCheck(char plr, char mpad)
 
             if (Mev[STEP].loc == 28 || Mev[STEP].loc == 27) {
                 strcpy(Mev[STEP].Name, (plr == 0) ? "bUC0" : "bSC0");
-                Mev[STEP].Name[5] = Mev[STEP].E->ID[1];
+                Mev[STEP].Name[5] = GetEquipment(Mev[STEP])->ID[1];
             }
 
-            if (strncmp(Mev[STEP].E->Name, "DO", 2) == 0) {
+            if (strncmp(GetEquipment(Mev[STEP])->Name, "DO", 2) == 0) {
                 if (Mev[STEP].loc == 2) {
                     Data->P[plr].DockingModuleInOrbit = 2;
                 }
@@ -561,8 +561,8 @@ void MisCheck(char plr, char mpad)
                 Mev[STEP].trace = STEP + 1;
             }
 
-            if (!(strncmp(Mev[STEP].E->Name, "DO", 2) == 0 && Mev[STEP].loc == 0x02)) {
-                Mev[STEP].E->MisSucc++;  // set for all but docking power on
+            if (!(strncmp(GetEquipment(Mev[STEP])->Name, "DO", 2) == 0 && Mev[STEP].loc == 0x02)) {
+                GetEquipment(Mev[STEP])->MisSucc++;  // set for all but docking power on
             }
 
             Mev[STEP].StepInfo = 1;
@@ -797,12 +797,12 @@ void F_KillCrew(char mode, struct Astros *Victim)
 
     // TODO: Need to set the Base as the minimum value when dividing by 2
     if ((Data->Def.Lev1 == 0 && p == 0) || (Data->Def.Lev2 == 0 && p == 1)) {
-        Mev[STEP].E->Safety /= 2;
+        GetEquipment(Mev[STEP])->Safety /= 2;
     } else {
-        Mev[STEP].E->Safety = Mev[STEP].E->Base;
+        GetEquipment(Mev[STEP])->Safety = GetEquipment(Mev[STEP])->Base;
     }
 
-    Mev[STEP].E->MaxRD = Mev[STEP].E->MSF - 1;
+    GetEquipment(Mev[STEP])->MaxRD = GetEquipment(Mev[STEP])->MSF - 1;
 
     if (mode == F_ALL) {
         for (k = 0; k < MANNED[Mev[STEP].pad]; k++) {  // should work in news
@@ -866,8 +866,8 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
     temp = 0; /* XXX check uninitialized */
 
-    if (!(strncmp(Mev[STEP].E->Name, "DO", 2) == 0 && Mev[STEP].loc == 0x02)) {
-        Mev[STEP].E->MisFail++;  // set failure for all but docking power on
+    if (!(strncmp(GetEquipment(Mev[STEP])->Name, "DO", 2) == 0 && Mev[STEP].loc == 0x02)) {
+        GetEquipment(Mev[STEP])->MisFail++;  // set failure for all but docking power on
     }
 
     Mev[STEP].StepInfo = 1003;
@@ -886,7 +886,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
         // Special Case for PhotoRecon with Lunar Probe
         if (Mev[STEP].loc == 20 && mcc == Mission_Lunar_Probe) {
-            Mev[STEP - 1].E->MisFail++;
+            GetEquipment(Mev[STEP - 1])->MisFail++;
         }
 
         return 0;
@@ -921,7 +921,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
     case 3:  // Kill ALL Crew and END Mission
         FNote = 8;
 
-        if (InSpace > 0 && MANNED[Mev[STEP].pad] == 0 && strncmp(Mev[STEP].E->ID, "M2", 2) == 0) {
+        if (InSpace > 0 && MANNED[Mev[STEP].pad] == 0 && strncmp(GetEquipment(Mev[STEP])->ID, "M2", 2) == 0) {
             Mev[STEP].pad = other(Mev[STEP].pad);  // for Kicker-C problems
             F_KillCrew(F_ALL, 0);
             Mev[STEP].pad = other(Mev[STEP].pad);
@@ -952,10 +952,10 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
     case 6:   // Reduce Safety by VAL% temp
         FNote = 0;
-        Mev[STEP].E->MisSaf -= abs(val);
+        GetEquipment(Mev[STEP])->MisSaf -= abs(val);
 
-        if (Mev[STEP].E->MisSaf <= 0) {
-            Mev[STEP].E->MisSaf = 1;
+        if (GetEquipment(Mev[STEP])->MisSaf <= 0) {
+            GetEquipment(Mev[STEP])->MisSaf = 1;
         }
 
         Mev[STEP].StepInfo = 900 + Mev[STEP].loc;
@@ -990,10 +990,10 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
     case 12:  // Subtract VAL% from Safety, repair Pad for XTRA (launch only)
         FNote = 5;
-        Mev[STEP].E->MisSaf -= abs(val);
+        GetEquipment(Mev[STEP])->MisSaf -= abs(val);
 
-        if (Mev[STEP].E->MisSaf <= 0) {
-            Mev[STEP].E->MisSaf = 1;
+        if (GetEquipment(Mev[STEP])->MisSaf <= 0) {
+            GetEquipment(Mev[STEP])->MisSaf = 1;
         }
 
         Mev[STEP].StepInfo = 1600 + Mev[STEP].loc;
@@ -1013,10 +1013,10 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
     case 15:  // Give option to Scrub  1%->20% negative of part
         FNote = 3;
-        Mev[STEP].E->MisSaf -= brandom(20) + 1;
+        GetEquipment(Mev[STEP])->MisSaf -= brandom(20) + 1;
 
-        if (Mev[STEP].E->MisSaf <= 0) {
-            Mev[STEP].E->MisSaf = 1;
+        if (GetEquipment(Mev[STEP])->MisSaf <= 0) {
+            GetEquipment(Mev[STEP])->MisSaf = 1;
         }
 
         Mev[STEP].StepInfo = 15;
@@ -1191,10 +1191,10 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
     case 24:   // Reduce Safety by VAL% perm :: hardware recovered
         FNote = 5;
-        Mev[STEP].E->Safety -= brandom(10);
+        GetEquipment(Mev[STEP])->Safety -= brandom(10);
 
-        if (Mev[STEP].E->Safety <= 0) {
-            Mev[STEP].E->Safety = 1;
+        if (GetEquipment(Mev[STEP])->Safety <= 0) {
+            GetEquipment(Mev[STEP])->Safety = 1;
         }
 
         Mev[STEP].StepInfo = 800 + Mev[STEP].loc;
@@ -1211,10 +1211,10 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
     case 26:  // Subtract VAL% from Equip perm and branch to alternate
         FNote = 1;
         Mev[STEP].StepInfo = 1926;
-        Mev[STEP].E->Safety -= brandom(10);
+        GetEquipment(Mev[STEP])->Safety -= brandom(10);
 
-        if (Mev[STEP].E->Safety <= 0) {
-            Mev[STEP].E->Safety = 1;
+        if (GetEquipment(Mev[STEP])->Safety <= 0) {
+            GetEquipment(Mev[STEP])->Safety = 1;
         }
 
         if (Mev[STEP].fgoto == -1) {
@@ -1245,7 +1245,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
         Mev[STEP].StepInfo = 3100 + STEP;
 
         {
-            std::vector<Astros *> crew = LMCrew(Mev[STEP].pad, Mev[STEP].E);
+            std::vector<Astros *> crew = LMCrew(Mev[STEP].pad, GetEquipment(Mev[STEP]));
 
             for (std::vector<Astros *>::iterator it = crew.begin();
                  it != crew.end(); it++) {
@@ -1344,7 +1344,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
         }
     }
 
-    if (strncmp(Mev[STEP].E->ID, "M3", 2) == 0) {
+    if (strncmp(GetEquipment(Mev[STEP])->ID, "M3", 2) == 0) {
         death = 0;    //what???
     }
 


### PR DESCRIPTION
Change pointer *E to union, keeping minimal size to 8 bytes even on 32
bit platform. Keep constant save size, should make also compatible saves
on both x86_64 and i686. It breaks old game save compatibility on 32 bit
system.

Replace strange pointer with a function, which should get always the
same pointer from structure. Relies on unverified expectation MH stays
constant.

Fixes issue #494 