### PR TITLE
Add helper >function to clear step failures for debugging purposes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,11 @@ endif (WINDOWS)
 
 option(PBEM "Enable experimental Play-by-EMail feature" OFF)
 
+string(TOLOWER "${CMAKE_BUILD_TYPE}" lc_CMAKE_BUILD_TYPE)
+if(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+	add_definitions(-DDEBUG)
+endif(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+
 add_subdirectory(lib)
 add_subdirectory(src)
 install(PROGRAMS icons/raceintospace.desktop DESTINATION share/applications)
@@ -46,8 +51,8 @@ add_custom_target(run
 	DEPENDS raceintospace
 	)
 
-string(TOLOWER "${CMAKE_BUILD_TYPE}" lc_CMAKE_BUILD_TYPE)
 if(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+	add_definitions(-DDEBUG)
 	add_custom_target(gdb
 		COMMAND gdb -ex run --args ${CMAKE_BINARY_DIR}/src/game/raceintospace BARIS_DATA=${CMAKE_SOURCE_DIR}/data
 		DEPENDS raceintospace

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -1483,3 +1483,15 @@ void BranchIfAlive(int *FNote)
         Mev[STEP].trace = 0x7f;
     }
 }
+
+/* Clear n steps for debugging purposes. */
+#ifdef DEBUG
+void clear_steps(int n)
+{
+    int i;
+
+    for (i = 0; i < n; i++) {
+        Mev[i].dice = -128;
+    }
+}
+#endif


### PR DESCRIPTION
Adds a function clear_steps that can be used to force the first n teps of a mission to always pass. The function is available only when building in debug mode and is meant to be called from a debugger.