### PR TITLE
Check for successful LEM activities before Lunar EVA dialog

### DIFF
--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -254,7 +254,7 @@ void MisCheck(char plr, char mpad)
             }
         }
 
-        if (Mev[STEP].loc == 16 && plan.PCat[4] == 22) {
+        if (Mev[STEP].loc == 16 && Mev[Mev[STEP].trace].loc == 15) {
             FirstManOnMoon(plr, 0, code);
         }
 


### PR DESCRIPTION
Fixes a bug that led to the dialog to choose the first person on the moon being shown even if the entire LM crew got killed. Introduces and additional check whether the subsequent step is the actual Lunar EVA. Fixes #476 and #514.