### PR TITLE
Fix AI downgrading to unmanned mission

### DIFF
--- a/src/game/aimis.cpp
+++ b/src/game/aimis.cpp
@@ -1474,7 +1474,7 @@ void AIFuture(char plr, char mis, char pad, char *prog)
 
                     while (mcode < 0) {
 
-                        std::string cName = missionData[replace.current().MissionCode].Name;
+                        std::string cName = missionData.at(replace.current().MissionCode).Name;
                         std::size_t pos = cName.find("MANNED");
 
                         if (pos != std::string::npos) {

--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -79,7 +79,7 @@ enum FMFields {
 bool JointFlag, MarsFlag, JupiterFlag, SaturnFlag;
 display::LegacySurface *vh;
 // missionData is used in SetParameters, PianoKey, UpSearchRout,
-// DownSearchRout, and Future.
+// DownSearchRout, Future, and GetMissionData.
 std::vector<struct mStr> missionData;
 } // End unnamed namespace
 
@@ -1053,10 +1053,11 @@ void Future(char plr)
                 if (misType == 17 || misType == 24 || misType == 28 || misType == 29) {
                     if (goAhead != 1) {
                         goAhead = Help("i167");
-                    } 
-                    if (goAhead != 1) { 
-                       OutBox(244, 5, 313, 17);
-                       continue; 
+                    }
+
+                    if (goAhead != 1) {
+                        OutBox(244, 5, 313, 17);
+                        continue;
                     }
                 } else {
                     if (! FutureMissionOk(plr, nav, misType)) {
@@ -1276,7 +1277,7 @@ void Future(char plr)
                 InBox(5, 24, 201, 47);
                 int helpIndex = 300 + misType;
                 char helpEntry[5];
-                snprintf(helpEntry, sizeof(helpEntry), "i%d03", helpIndex);                
+                snprintf(helpEntry, sizeof(helpEntry), "i%d03", helpIndex);
                 WaitForMouseUp();
                 delay(100);
                 OutBox(5, 24, 201, 47);
@@ -1583,6 +1584,12 @@ bool FutureMissionOk(char plr, const MissionNavigator &nav, int mis)
     }
 
     return true;
+}
+
+std::vector<struct mStr> GetMissionData()
+{
+    SetParameters();
+    return missionData;
 }
 
 

--- a/src/game/future.h
+++ b/src/game/future.h
@@ -1,7 +1,12 @@
 #ifndef FUTURE_H
 #define FUTURE_H
 
+#include <vector>
+
+#include "data.h"
+
 void Future(char plr);
 void MissionName(int val, int xx, int yy, int len);
+std::vector<struct mStr> GetMissionData();
 
 #endif // FUTURE_H


### PR DESCRIPTION
Fixes a bug when the AI cannot find enough 'nauts to fly a mission, which could trigger an infinite loop when the attempted mission had a duration step. The fix replaces the mission code by the most appropriate unmanned counterpart. Fixes #552.