### PR TITLE
Explain retirement due to mission injury in the news

### DIFF
--- a/src/game/data.h
+++ b/src/game/data.h
@@ -73,10 +73,10 @@
  *                 News specials
  * \li   1 = Retirement announcement
  * \li   2 = Actual retirement
- * \li   3 = ??? unused ???
- * \li   4 = ??? unused ???
+ * \li   3 = Death during mission
+ * \li   4 = Injury during mission
  * \li   5 = Injury resolution
- * \li   6 = ??? Breaking Group/Replacing Astronaut ???
+ * \li   6 = Removed from FLT crew
  * \li   7 = Finished Training
  * \li   8 = Finished Advanced
  * \li   9 = Injury during training

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -69,7 +69,7 @@ int MCGraph(char plr, int lc, int safety, int val, char prob);
 void F_KillCrew(char mode, struct Astros *Victim);
 void F_IRCrew(char mode, struct Astros *Guy);
 int FailEval(char plr, int type, char *text, int val, int xtra);
-Equipment* FindLunarModule();
+Equipment *FindLunarModule();
 std::vector<Astros *> LMCrew(int pad, Equipment *module);
 void InvalidatePrestige();
 void BranchIfAlive(int *FNote);
@@ -849,6 +849,7 @@ void F_IRCrew(char mode, struct Astros *Guy)
 
     if (mode == F_RET) {  // should work in news
         Guy->Status = AST_ST_RETIRED;
+        Guy->Special = 2;
         Guy->RetirementDelay = 1;  // Retire beginning of next season
         Guy->RetirementReason = 9;
         Guy->Assign = Guy->Moved = Guy->Crew = Guy->Task = Guy->Unassigned = 0;
@@ -1399,7 +1400,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
  *
  * \return the LM, or NULL if there is none for the mission.
  */
-Equipment* FindLunarModule()
+Equipment *FindLunarModule()
 {
     // For joint missions, the LM is always found on the first launch,
     // because if there's a problem launching it, there's no reason to

--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -198,8 +198,11 @@ OpenNews(char plr, char *buf, int bud)
             fread(&buf[bufsize], 50, 1, fp);
         }
 
+        /* Show reasons for retirement announcements, mission deaths (8), and
+           retirements due to mission injuries (9) */
+
         if (Data->P[plr].Pool[j].Special == 1
-            || (Data->P[plr].Pool[j].Special > 0 && Data->P[plr].Pool[j].RetirementReason == 8)) {
+            || (Data->P[plr].Pool[j].Special > 0 && (Data->P[plr].Pool[j].RetirementReason == 8 || Data->P[plr].Pool[j].RetirementReason == 9))) {
             //13 other things
             i = len[0] + len[1] + len[2] + (sizeof len) + 50 * (Data->P[plr].Pool[j].RetirementReason - 1);
 
@@ -255,6 +258,7 @@ OpenNews(char plr, char *buf, int bud)
     if (Data->P[plr].Plans & 0x0f) {
         // Failures
         display::graphics.setForegroundColor(6);
+
         if (Data->P[plr].Plans & 0x01) {
             strcpy(&buf[strlen(buf)], "MARS FLYBY FAILS!x");
         }
@@ -270,6 +274,7 @@ OpenNews(char plr, char *buf, int bud)
 
     if (Data->P[plr].Plans & 0xf0) {
         display::graphics.setForegroundColor(5);
+
         if (Data->P[plr].Plans & 0x10) {
             display::graphics.setForegroundColor(13);
             strcpy(&buf[strlen(buf)], "MARS FLYBY SUCCEEDS!x");
@@ -841,16 +846,17 @@ News(char plr)
             OutBox(303, 158, 313, 194);
         }
 
-    if (ctop <= 0) {
-        draw_up_arrow(305, 126);
-    } else {
-        draw_up_arrow_highlight(305, 126);
-    }
-    if (ctop >= bline) {
-        draw_down_arrow(305, 163);
-    } else {
-        draw_down_arrow_highlight(305, 163);
-    }
+        if (ctop <= 0) {
+            draw_up_arrow(305, 126);
+        } else {
+            draw_up_arrow_highlight(305, 126);
+        }
+
+        if (ctop >= bline) {
+            draw_down_arrow(305, 163);
+        } else {
+            draw_down_arrow_highlight(305, 163);
+        }
 
 //   gr_sync ();
     }


### PR DESCRIPTION
Fixes a bug that led to mission injuries causing immediate retirement not being announced in the news. Also improves the documentation of Astros::Special variable. Fixes #568.