### PR TITLE
Fix cmake if condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ endif (WINDOWS)
 option(PBEM "Enable experimental Play-by-EMail feature" OFF)
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" lc_CMAKE_BUILD_TYPE)
-if(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+if("${lc_CMAKE_BUILD_TYPE}" STREQUAL "debug")
 	add_definitions(-DDEBUG)
-endif(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+endif("${lc_CMAKE_BUILD_TYPE}" STREQUAL "debug")
 
 add_subdirectory(lib)
 add_subdirectory(src)
@@ -51,18 +51,18 @@ add_custom_target(run
 	DEPENDS raceintospace
 	)
 
-if(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+if("${lc_CMAKE_BUILD_TYPE}" STREQUAL "debug")
 	add_definitions(-DDEBUG)
 	add_custom_target(gdb
 		COMMAND gdb -ex run --args ${CMAKE_BINARY_DIR}/src/game/raceintospace BARIS_DATA=${CMAKE_SOURCE_DIR}/data
 		DEPENDS raceintospace
 		)
-else(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+else("${lc_CMAKE_BUILD_TYPE}" STREQUAL "debug")
 	add_custom_target(gdb
 		COMMENT "Set CMAKE_BUILD_TYPE=Debug for debugging information (e.g., \"cmake -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}\")"
 		COMMAND false
 		)
-endif(${lc_CMAKE_BUILD_TYPE} STREQUAL "debug")
+endif("${lc_CMAKE_BUILD_TYPE}" STREQUAL "debug")
 
 add_custom_target(tag
 	COMMAND ${GIT} tag -a v${CMAKE_PROJECT_VERSION})


### PR DESCRIPTION
In IF conditions the variable either has to be quoted or the variable
has to be written without dollar and bracket signs, otherwise cmake will
fail with a syntax error fail if the build type is not set. Using the former
syntax to fix this.