### PR TITLE
Do not download physfs if already installed

### DIFF
--- a/lib/Global.cmake
+++ b/lib/Global.cmake
@@ -119,7 +119,7 @@ endif (NOT DEFINED BUILD_JSONCPP)
 
 if (NOT DEFINED BUILD_PHYSFS)
   find_library(Physfs_LIBRARY NAMES physfs)
-  find_path(Physfs_INCLUDE_DIR json/json.h physfs)
+  find_path(Physfs_INCLUDE_DIR physfs.h)
   if (NOT Physfs_LIBRARY OR NOT Physfs_INCLUDE_DIR)
     set(BUILD_PHYSFS ON)
     set(Physfs_LIBRARY physfs)


### PR DESCRIPTION
Fixes the check whether the physfs library is available system-wide so it does not get downloaded if already installed.