### PR TITLE
Fix symbol images used in header text

### DIFF
--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -2,6 +2,7 @@
 
 #include "draw.h"
 #include "gr.h"
+#include "logging.h"
 #include "pace.h"
 #include "sdlhelper.h"
 #include "filesystem.h"
@@ -13,6 +14,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+
+
+LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT);
+
 
 /** Print string at specific position
  *
@@ -81,19 +86,20 @@ void draw_heading(int x, int y, const char *txt, char mode, char te)
     for (i = 0; i < (int)strlen(txt); i++) {
         if (txt[i] == 0x20) {
             x += 6;
-            i++;
+            continue;
         }
 
         c = toupper(txt[i] & 0xff);
 
-        if (c >= 0x30 && c <= 0x39) {
+        // Map the ASCII code to the image index.
+        // Currently, no image exists for the '@' character.
+        if (c >= 0x20 && c <= 0x3F) {
             px = c - 32;
-        } else {
+        } else if (c >= 0x41 && c <= 0x60) {
             px = c - 33;
-        }
-
-        if (c == '-') {
-            px++;
+        } else {
+            WARNING2("Cannot print header character %c", txt[i]);
+            continue;
         }
 
         // Read into letter piecewise to avoid packing issues.


### PR DESCRIPTION
Display special characters correctly in header text. An off-by-one error
substituted the wrong image files when printing symbols (ex: ! for ").
Fixes #566.