### PR TITLE
Enable certain config options without segfault

### DIFF
--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -145,13 +145,13 @@ static struct {
         "Set to zero to require assigning a Backup crew (Classic setting)."
     },   // No Backup crew required -Leon
     {
-        "show_recruit_stats", &options.feat_show_recruit_stats, "%u", 1,
+        "show_recruit_stats", &options.feat_show_recruit_stats, "%u", 0,
         "By default astronaut/cosmonaut candidate stats are revealed based"
-        "\n# on Astronaut difficulty. Set to 0 to restore the classic"
+        "\n# on Astronaut difficulty. Set to 0 to restore the classic "
         "setting\n# where only Capsule and Endurance are shown."
     },   // Depending on difficulty, show recruit's Docking, EVA, LM
     {
-        "use_endurance", &options.feat_use_endurance, "%u", 1,
+        "use_endurance", &options.feat_use_endurance, "%u", 0,
         "Add the crew's endurance when making duration tests, and when "
         "avoiding injury.\n# Set to 0 to disabled (Classic setting)."
 


### PR DESCRIPTION
Fixes the `show_recruit_stats` and `use_endurance` configuration options
so they will no longer cause a segmentation fault. The need_alloc fields
for the corresponding entries in the config_string array were
accidentally being set non-zero. This caused inappropriate memory
reallocation attempts, leading to a segmentation fault.