### PR TITLE
Stop tech safety from exceeding maximum

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -890,7 +890,7 @@ void MissionSetDown(char plr, char mis)
                 MH[j][i]->SMods = MH[j][i]->Damage = MH[j][i]->DCost = 0;
 
                 if (strncmp(MH[j][i]->Name, (i == Mission_Probe_DM) ? "DOC" : "PHO", 3) != 0 && MH[j][i]->MisSucc > 0) {
-                    MH[j][i]->Safety++;
+                    MH[j][i]->Safety = MIN(MH[j][i]->Safety + 1, MH[j][i]->MaxSafety);
 
                     if (options.cheat_addMaxS) {
                         MH[j][i]->MaxRD++;
@@ -921,7 +921,9 @@ void MissionSetDown(char plr, char mis)
                 if (i == Mission_PrimaryBooster &&
                     MH[j][Mission_SecondaryBooster] != NULL) { // Boosters
                     if (MH[j][Mission_PrimaryBooster]->MisSucc > 0)  {
-                        MH[j][Mission_SecondaryBooster]->Safety++;
+                        MH[j][Mission_SecondaryBooster]->Safety =
+                            MIN(MH[j][Mission_SecondaryBooster]->Safety + 1,
+                                MH[j][Mission_SecondaryBooster]->MaxSafety);
 
                         if (options.cheat_addMaxS) {
                             MH[j][Mission_SecondaryBooster]->MaxRD++;


### PR DESCRIPTION
Prevents hardware program safety from being improved above the program
maximum after a successful mission. When component safety was improved
after successful use in a mission, the safety value was not being
limited to the program's MaxSafety value until start-of-turn
maintenance.