### PR TITLE
Convert C standard library headers to C++ versions

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -1,13 +1,15 @@
 #include "graphics.h"
-#include "surface.h"
-#include "legacy_surface.h"
 
-#include <SDL/SDL.h>
+#include <cassert>
 #include <string>
 #include <vector>
 #include <stdexcept>
-#include <assert.h>
-#include <memory.h>
+#include <memory>
+
+#include <SDL/SDL.h>
+
+#include "surface.h"
+#include "legacy_surface.h"
 
 // FIXME: let's try to avoid this
 #include "../game/sdlhelper.h"

--- a/src/display/image.cpp
+++ b/src/display/image.cpp
@@ -1,17 +1,18 @@
 #include "image.h"
 
+#include <cassert>
+#include <cerrno>
+#include <stdexcept>
+#include <string>
+
+#include <boost/format.hpp>
+#include <png.h>
+#include <zlib.h>
+
 #include "graphics.h"
 #include "surface.h"
 #include "palettized_surface.h"
 
-#include <png.h>
-#include <zlib.h>
-#include <assert.h>
-#include <errno.h>
-
-#include <boost/format.hpp>
-#include <string>
-#include <stdexcept>
 
 namespace display
 {

--- a/src/display/image.h
+++ b/src/display/image.h
@@ -1,16 +1,17 @@
 #ifndef DISPLAY_IMAGE_H
 #define DISPLAY_IMAGE_H
 
-#include "palette.h"
-#include "graphics.h"
-#include "surface.h"
-#include "palettized_surface.h"
-
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <SDL/SDL.h>
 
 #include <boost/shared_ptr.hpp>
+
+#include "graphics.h"
+#include "palette.h"
+#include "palettized_surface.h"
+#include "surface.h"
+
 
 namespace display
 {

--- a/src/display/legacy_surface.cpp
+++ b/src/display/legacy_surface.cpp
@@ -1,9 +1,9 @@
 #include "legacy_surface.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <cstdlib>
 #include <algorithm>
+
 
 namespace display
 {

--- a/src/display/palette.cpp
+++ b/src/display/palette.cpp
@@ -1,8 +1,10 @@
-#include <memory.h>
-#include <assert.h>
+#include "palette.h"
+
+#include <cassert>
+#include <memory>
 
 #include "graphics.h"
-#include "palette.h"
+
 
 namespace display
 {

--- a/src/display/palette.h
+++ b/src/display/palette.h
@@ -2,9 +2,12 @@
 #define DISPLAY__PALETTE_H
 
 #include "color.h"
-#include <stdio.h>
+
+#include <cassert>
+#include <cstdio>
+
 #include <SDL/SDL.h>
-#include <assert.h>
+
 
 namespace display
 {

--- a/src/display/palettized_surface.cpp
+++ b/src/display/palettized_surface.cpp
@@ -1,6 +1,7 @@
 #include "palettized_surface.h"
 
-#include <assert.h>
+#include <cassert>
+
 
 namespace display
 {

--- a/src/display/surface.cpp
+++ b/src/display/surface.cpp
@@ -1,9 +1,10 @@
-
 #include "surface.h"
 
-#include <SDL/SDL.h>
+#include <cassert>
 #include <algorithm>
-#include <assert.h>
+
+#include <SDL/SDL.h>
+
 
 namespace display
 {

--- a/src/game/Buzz_inc.h
+++ b/src/game/Buzz_inc.h
@@ -38,10 +38,11 @@ extern "C" {
 #include <winsock2.h>
 #endif
 
-#include <string.h>
-#include <math.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
 #include <SDL/SDL_config.h> // declares some of the same symbols as our config
+
 #include "raceintospace_config.h"
 #include "logging.h"
 #include "gamedata.h"

--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -30,8 +30,10 @@
 // This file handles the Administration building and some of its subsections: Future Missions, Time Capsule (save/load game).
 // It also includes some code for Modem and PBEM.
 
-#include <assert.h>
+#include "admin.h"
 
+#include <cassert>
+#include <cctype>
 #include <algorithm>
 #include <vector>
 
@@ -39,7 +41,6 @@
 #include "display/surface.h"
 #include "display/palettized_surface.h"
 
-#include "admin.h"
 #include "Buzz_inc.h"
 #include "utils.h"
 #include "ast1.h"
@@ -61,7 +62,6 @@
 #include "filesystem.h"
 #include "options.h"
 
-#include <ctype.h>
 
 #define MODEM_ERROR 4
 #define NOTSAME 2

--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -1,19 +1,20 @@
 // This file defines how characters are printed on the screen
 
 #include "draw.h"
-#include "gr.h"
-#include "logging.h"
-#include "pace.h"
-#include "sdlhelper.h"
-#include "filesystem.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include "filesystem.h"
+#include "gr.h"
+#include "logging.h"
+#include "pace.h"
+#include "sdlhelper.h"
 
 
 LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT);

--- a/src/game/endianness.cpp
+++ b/src/game/endianness.cpp
@@ -1,7 +1,10 @@
-#include "Buzz_inc.h"
-#include <assert.h>
 #include "endianness.h"
+
+#include <cassert>
+
+#include "Buzz_inc.h"
 #include "game_main.h"
+
 
 // Need these functions to always exist
 uint32_t _Swap32bit(uint32_t value)

--- a/src/game/file.cpp
+++ b/src/game/file.cpp
@@ -1,9 +1,10 @@
-#include <assert.h>
-#include <physfs.h>
+#include "file.h"
 
+#include <cassert>
 #include <stdexcept>
 
-#include "file.h"
+#include <physfs.h>
+
 
 #define m_phys_handle ((PHYSFS_File*)m_handle)
 

--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -1,13 +1,14 @@
-#include <assert.h>
-#include <physfs.h>
+#include "filesystem.h"
 
+#include <cassert>
 #include <stdexcept>
+
 #include <boost/format.hpp>
+#include <physfs.h>
 
 #include "display/image.h"
 
 #include "raceintospace_config.h"
-#include "filesystem.h"
 
 using boost::format;
 

--- a/src/game/fortify_workaround.cpp
+++ b/src/game/fortify_workaround.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include "fortify_workaround.h"
+
 
 #if _FORTIFY_SOURCE > 0
 

--- a/src/game/fortify_workaround.h
+++ b/src/game/fortify_workaround.h
@@ -1,7 +1,7 @@
 #ifndef _FORTIFY_WORKAROUND_
 #define _FORTIFY_WORKAROUND_
 
-#include <stdio.h>
+#include <cstdio>
 
 /*
  * there are over 100 places that call fread without checking the

--- a/src/game/fs.cpp
+++ b/src/game/fs.cpp
@@ -21,16 +21,20 @@
  *
  */
 
+#include "fs.h"
+
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+
+#include <sys/stat.h>
+#include <physfs.h>
+
 #include "Buzz_inc.h"
-#include "raceintospace_config.h"
 #include "options.h"
 #include "pace.h"
+#include "raceintospace_config.h"
 #include "utils.h"
-#include <assert.h>
-#include <sys/stat.h>
-#include <errno.h>
-#include <ctype.h>
-#include <physfs.h>
 
 /** path separator setup */
 #ifndef PATHSEP

--- a/src/game/fs.h
+++ b/src/game/fs.h
@@ -1,9 +1,10 @@
 #ifndef _FS_H
 #define _FS_H
 
-#include <stdio.h>
-#include <physfs.h>
+#include <cstdio>
 #include <string>
+
+#include <physfs.h>
 
 /** \file fs.h Definitions for filesystem
  *

--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -21,12 +21,12 @@
 
 #include "future.h"
 
+#include <cassert>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/palettized_surface.h"
 #include "display/legacy_surface.h"
-
-#include <assert.h>
 
 #include "Buzz_inc.h"
 #include "admin.h"

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -26,24 +26,26 @@
 //*                                                              *
 //****************************************************************
 
-#include <errno.h>
-#include <ctype.h>
-#include <assert.h>
+#include <cassert>
+#include <cctype>
+#include <cerrno>
 #include <math.h>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include "filesystem.h"
 #include "Buzz_inc.h"
-#include "game_main.h"
-#include "options.h"
-#include "utils.h"
+#include "game_main.h"  // Below Buzz_inc.h b/c game_main.h needs data.h
 #include "admin.h"
 #include "aimast.h"
 #include "ast4.h"
+#include "crash.h"
+#include "crew.h"
 #include "endgame.h"
+#include "endianness.h"
+#include "filesystem.h"
+#include "gr.h"
 #include "hardware.h"
 #include "intel.h"
 #include "intro.h"
@@ -52,20 +54,18 @@
 #include "museum.h"
 #include "newmis.h"
 #include "news.h"
+#include "options.h"
+#include "pace.h"
+#include "pbm.h"
 #include "place.h"
 #include "port.h"
 #include "prefs.h"
 #include "records.h"
 #include "review.h"
+#include "sdlhelper.h"
 #include "start.h"
 #include "state_utils.h"
-#include "pace.h"
-#include "sdlhelper.h"
-#include "gr.h"
-#include "crash.h"
-#include "endianness.h"
-#include "crew.h"
-#include "pbm.h"
+#include "utils.h"
 
 #ifdef CONFIG_MACOSX
 // SDL.h needs to be included here to replace the original main() with

--- a/src/game/gamedata.cpp
+++ b/src/game/gamedata.cpp
@@ -1,5 +1,7 @@
-#include <stdio.h>
 #include "gamedata.h"
+
+#include <cstdio>
+
 
 static inline uint8_t
 get_uint8_t(const void *buf)

--- a/src/game/gamedata.h
+++ b/src/game/gamedata.h
@@ -8,7 +8,8 @@
 #endif
 
 #include <stdint.h>
-#include <stdio.h>
+
+#include <cstdio>
 
 /** Routines for read/write access to LITTLE ENDIAN data in game files */
 extern size_t fread_uint8_t(uint8_t *dst, size_t nelem, FILE *file);

--- a/src/game/gr.cpp
+++ b/src/game/gr.cpp
@@ -1,12 +1,14 @@
+#include "gr.h"
+
+#include <cassert>
+
+#include <boost/swap.hpp>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 
-#include "gr.h"
 #include "Buzz_inc.h"
-#include <assert.h>
 #include "sdlhelper.h"
-
-#include <boost/swap.hpp>
 
 using boost::swap;
 

--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -28,8 +28,7 @@
 
 #include "intel.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <stdexcept>
 
 #include "display/graphics.h"

--- a/src/game/log4c.cpp
+++ b/src/game/log4c.cpp
@@ -31,10 +31,14 @@
  *
  * See log4c.h for documentation.
  */
+#include "log4c.h"
+
+#include <cstdlib>
+#include <cassert>
+
 #include "logging.h"
 #include "macros.h"
-#include <stdlib.h>
-#include <assert.h>
+
 
 struct LogCategory _LOGV(LOG_ROOT_CAT) = {
     0, 0, 0,

--- a/src/game/log4c.h
+++ b/src/game/log4c.h
@@ -203,7 +203,7 @@
 #ifndef _LOG4C_H_
 #define _LOG4C_H_
 
-#include <stdarg.h>
+#include <cstdarg>
 
 #ifdef ALTERED_STRUCTURE_PACKING
 #error "log4c breaks when you include it late"

--- a/src/game/log_default.cpp
+++ b/src/game/log_default.cpp
@@ -25,8 +25,10 @@
  */
 
 #include "log4c.h"
+
+#include <cstdio>
+
 #include "macros.h"
-#include <stdio.h>
 
 /**
  * The root category's default logging function.

--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -25,13 +25,14 @@
 
 // This file handles missions in progress, particularly mission failures and their results
 
-#include <assert.h>
+#include "mis_c.h"
+
+#include <cassert>
 #include <vector>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 
-#include "mis_c.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "draw.h"

--- a/src/game/mmfile.cpp
+++ b/src/game/mmfile.cpp
@@ -18,16 +18,20 @@
 
 // This file handles multimedia files
 
-#include <math.h>
-#include <assert.h>
-#include <stdio.h>
-#include <memory.h>
-#include <stdlib.h>
-#include <limits.h>
+#include "mmfile.h"
+
+#include <stdint.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <limits>
+
 #include <ogg/ogg.h>
 #include <vorbis/codec.h>
 #include <theora/theora.h>
-#include <stdint.h>
 #include <SDL/SDL.h>
 
 #include "raceintospace_config.h"
@@ -38,7 +42,6 @@
 #include "fake_unistd.h"
 #endif
 
-#include "mmfile.h"
 #include "macros.h"
 #include "utils.h"
 #include "logging.h"

--- a/src/game/mmfile.h
+++ b/src/game/mmfile.h
@@ -1,11 +1,14 @@
 #ifndef _MM_FILE_H
 #define _MM_FILE_H
 
-#include <stdio.h>
+#include <cstdio>
+
 #include <ogg/ogg.h>
 #include <vorbis/codec.h>
 #include <theora/theora.h>
 #include <SDL/SDL.h>
+
+
 enum stream_type {
     MEDIA_AUDIO = 1,
 

--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -18,20 +18,23 @@
 
 // This file handles Advanced Preferences.
 
-#include "Buzz_inc.h"
 #include "options.h"
+
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <SDL/SDL.h>
+
+#include "Buzz_inc.h"
 #include "macros.h"
 #include "pace.h"
 #include "fs.h"
 #include "utils.h"
 #include "logging.h"
-#include <assert.h>
-#include <ctype.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <SDL/SDL.h>
 
 #define ENVIRON_DATADIR ("BARIS_DATA")
 #define ENVIRON_SAVEDIR ("BARIS_SAVE")

--- a/src/game/pace.cpp
+++ b/src/game/pace.cpp
@@ -1,19 +1,20 @@
 // This file is something to do with processing audio files
 
-#include <assert.h>
+#include "pace.h"
+
+#include <cassert>
+#include <cctype>
 
 #include "display/graphics.h"
 #include "display/surface.h"
 
 #include "Buzz_inc.h"
-#include "pace.h"
 #include "utils.h"
 #include "game_main.h"
 #include "sdlhelper.h"
 #include "gr.h"
 #include "mmfile.h"
 
-#include <ctype.h>
 
 void randomize(void);
 void SMove(void *p, int x, int y);

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -20,7 +20,7 @@
 
 #include "place.h"
 
-#include <assert.h>
+#include <cassert>
 #include <stdexcept>
 #include <string>
 

--- a/src/game/port.cpp
+++ b/src/game/port.cpp
@@ -25,11 +25,16 @@
 
 // This file handles the main Spaceport screen, including animations
 
+#include "port.h"
+
+#include <cstdio>
+
+#include <boost/shared_ptr.hpp>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include "port.h"
 #include "Buzz_inc.h"
 #include "draw.h"
 #include "utils.h"
@@ -56,8 +61,6 @@
 #include "endianness.h"
 #include "filesystem.h"
 
-#include <stdio.h>
-#include <boost/shared_ptr.hpp>
 
 #define LET_A   0x09
 #define LET_M   0x0A

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -25,11 +25,14 @@
 
 // This file handles original (main) game Preferences
 
+#include "prefs.h"
+
+#include <cctype>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include "prefs.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "admin.h"
@@ -42,7 +45,6 @@
 #include "pace.h"
 #include "filesystem.h"
 
-#include <ctype.h>
 
 struct DisplayContext {
     boost::shared_ptr<display::PalettizedSurface> prefs_image;

--- a/src/game/randomize.cpp
+++ b/src/game/randomize.cpp
@@ -33,20 +33,21 @@ Initial Cost is a random number, loosely based on the Basic Model initial cost
 Unit Cost is loosely based on the Basic Model, but depends on initial cost
 RD cost is loosely based on the Basic Model
 */
+#include "randomize.h"
+
+#include <cassert>
+#include <cctype>
 
 #include "display/graphics.h"
 
-#include "randomize.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
-#include <assert.h>
 #include "game_main.h"
 #include "gr.h"
 #include "draw.h"
 #include "pace.h"
 #include "sdlhelper.h"
 
-#include <ctype.h>
 
 /*random_number divides the randomization in 2,
  so there is a lower chance of getting an extreme */

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -25,11 +25,12 @@
 
 // This file handles replay of missions (I think).
 
-#include <assert.h>
+#include "replay.h"
+
+#include <cassert>
 
 #include "display/graphics.h"
 
-#include "replay.h"
 #include "gamedata.h"
 #include "Buzz_inc.h"
 #include "mmfile.h"

--- a/src/game/roster.cpp
+++ b/src/game/roster.cpp
@@ -1,12 +1,14 @@
-#include <json/json.h>
-#include <assert.h>
+#include "roster.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <fstream>
 
 #include <boost/foreach.hpp>
+#include <json/json.h>
 
-#include <fstream>
-#include <stdlib.h>
-#include "roster.h"
 #include "fs.h"
+
 
 Roster::Roster(std::istream &input_stream)
 {

--- a/src/game/roster_entry.cpp
+++ b/src/game/roster_entry.cpp
@@ -1,11 +1,11 @@
 #include "roster_entry.h"
-#include "roster_group.h"
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 #include "options.h"
 #include "pace.h"
+#include "roster_group.h"
 
 RosterEntry::RosterEntry(const RosterGroup &group, const Json::Value &json_object)
     : m_group_number(group.getGroupNumber())

--- a/src/game/roster_group.cpp
+++ b/src/game/roster_group.cpp
@@ -1,6 +1,7 @@
 #include "roster_group.h"
 
-#include <assert.h>
+#include <cassert>
+
 #include <boost/foreach.hpp>
 
 RosterGroup::RosterGroup(int player, int group_number, const Json::Value &json_object)

--- a/src/game/sdlhelper.cpp
+++ b/src/game/sdlhelper.cpp
@@ -25,15 +25,16 @@
  */
 
 // This file helps with processing A/V.
+#include "sdlhelper.h"
 
+#include <cassert>
+#include <memory>
+
+#include <SDL/SDL.h>
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "raceintospace_config.h"
 
-#include "sdlhelper.h"
-#include <assert.h>
-#include <memory.h>
-#include <SDL/SDL.h>
 #include "Buzz_inc.h"
 #include "options.h"
 #include "utils.h"

--- a/src/game/utils.cpp
+++ b/src/game/utils.cpp
@@ -1,10 +1,12 @@
 #include "utils.h"
+
+#include <cassert>
+#include <cctype>
+#include <cerrno>
+#include <cstring>
+#include <memory>
+
 #include "logging.h"
-#include <assert.h>
-#include <errno.h>
-#include <ctype.h>
-#include <string.h>
-#include <memory.h>
 #include "raceintospace_config.h"
 
 #ifdef HAVE_SYS_TYPES_H

--- a/src/game/utils.h
+++ b/src/game/utils.h
@@ -1,9 +1,10 @@
 #ifndef _UTILS_H
 #define _UTILS_H
 
+#include <cstdio>
+#include <cstdlib>
+
 #include <sys/types.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 #include "raceintospace_config.h"
 

--- a/src/utils/data_decoder.cpp
+++ b/src/utils/data_decoder.cpp
@@ -1,11 +1,12 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include <stdint.h>
-#include <errno.h>
-#include <string.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <jsoncpp/json/json.h>
-#include <assert.h>
 
 void print_escaped_string(const char *string, int max_length)
 {

--- a/src/utils/news2png.cpp
+++ b/src/utils/news2png.cpp
@@ -1,6 +1,7 @@
-#include <errno.h>
 #include <stdint.h>
-#include <stdio.h>
+
+#include <cerrno>
+#include <cstdio>
 #include <sstream>
 
 #include <png.h>


### PR DESCRIPTION
Replace C headers with their C++ versions. Per the C++ standard, the C++
version is preferred except when maintaining strict compatibility with
C, which RIS does not.