### PR TITLE
Eliminate most string literal conversion warnings

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -116,11 +116,11 @@ std::vector<SFInfo> GenerateTables(SaveGameType saveType);
 std::string GetBlockName();
 SaveGameType GetSaveType(const SaveFileHdr &header);
 void BadFileType();
-void FileText(char *name);
+void FileText(const char *name);
 int FutureCheck(char plr, char type);
 void LoadGame(const char *filename);
 bool OrderSaves(const SFInfo &a, const SFInfo &b);
-char RequestX(char *s, char md);
+char RequestX(const char *s, char md);
 int SaveGame(const std::vector<SFInfo> savegames);
 
 namespace
@@ -926,7 +926,7 @@ SaveGameType GetSaveType(const SaveFileHdr &header)
  *
  * \param name  The filename to write the save under.
  */
-void save_game(char *name)
+void save_game(const char *name)
 {
     FILE *outf;
     SaveFileHdr hdr;
@@ -1082,7 +1082,7 @@ void BadFileType()
  *
  * \param name  A savegame filename.
  */
-void FileText(char *name)
+void FileText(const char *name)
 {
     FILE *fin;
     SaveFileHdr header;
@@ -1659,7 +1659,7 @@ bool OrderSaves(const SFInfo &a, const SFInfo &b)
  * \param md  1 if the background underneath should be redrawn on close.
  * \return  1 for yes, 0 for no.
  */
-char RequestX(char *s, char md)
+char RequestX(const char *s, char md)
 {
     char i;
     display::LegacySurface local(196, 84);

--- a/src/game/admin.h
+++ b/src/game/admin.h
@@ -8,6 +8,6 @@ void CacheCrewFile();
 int32_t EndOfTurnSave(char *inData, int dataLen);  // Create ENDTURN.TMP
 void FileAccess(char mode);
 int FutureCheck(char plr, char type);
-void save_game(char *name);
+void save_game(const char *name);
 
 #endif // ADMIN_H

--- a/src/game/ast3.cpp
+++ b/src/game/ast3.cpp
@@ -59,7 +59,7 @@ void InjuredNautCenter(char plr, int sel);
 void DrawTrain(char plr, char lvl)
 {
     char TrnName[20];
-    char *Trner = "TRAINING\0";
+    const char *Trner = "TRAINING\0";
 
     if (lvl == 0) {
         helpText = "i038";

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -105,7 +105,7 @@ char AI[2] = {0, 0};
 // Used to hold mid-turn save game related information
 INTERIMDATA interimData;
 
-char *S_Name[] = {
+const char *S_Name[] = {
     "LAUNCH",
     "ORBITAL INS. BURN",
     "HARDWARE POWER-ON",

--- a/src/game/game_main.h
+++ b/src/game/game_main.h
@@ -44,7 +44,7 @@ extern int key;
 extern char Name[20];
 extern char *buffer;
 extern int32_t xMODE;
-extern char *S_Name[];
+extern const char *S_Name[];
 extern INTERIMDATA interimData;
 
 #endif // GAME_MAIN_H

--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -114,8 +114,8 @@ void PlaySequence(char plr, int step, const char *InSeq, char mode)
     struct oFGROUP *dSeq, cSeq;
     struct Table *F;
     char sName[20], err = 0;
-    char *SEQ_DAT = "SEQ.DAT";
-    char *FSEQ_DAT = "FSEQ.DAT";
+    const char *SEQ_DAT = "SEQ.DAT";
+    const char *FSEQ_DAT = "FSEQ.DAT";
     mm_file vidfile;
     FILE *mmfp;
     float fps;

--- a/src/game/music_none.cpp
+++ b/src/game/music_none.cpp
@@ -31,7 +31,7 @@
 // A map of music_tracks to filenames
 struct music_key {
     enum music_track track;
-    char *name;
+    const char *name;
 } music_key[] = {
     { M_ASSEMBLY, "assembly" },
     { M_ASTTRNG, "asttrng" },

--- a/src/game/music_vorbis.cpp
+++ b/src/game/music_vorbis.cpp
@@ -29,7 +29,7 @@
 // A map of music_tracks to filenames
 struct music_key {
     enum music_track track;
-    char *name;
+    const char *name;
 } music_key[] = {
     { M_ASSEMBLY, "assembly" },
     { M_ASTTRNG, "asttrng" },

--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -49,7 +49,7 @@
 
 /* LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT); */
 
-static char *news_shots[] = { "angle", "opening", "closing" };
+static const char *news_shots[] = { "angle", "opening", "closing" };
 
 double load_news_anim_start;
 

--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -76,20 +76,20 @@ LOG_DEFAULT_CATEGORY(config)
 
 /*set up array for environment vars */
 static struct {
-    char *name;
+    const char *name;
     char **dest;
-    char *def_val;
+    const char *def_val;
 } env_vars[] = {
     {ENVIRON_DATADIR, &options.dir_gamedata, DEFAULT_DATADIR},
     {ENVIRON_SAVEDIR, &options.dir_savegame, DEFAULT_SAVEDIR},
 };
 
-static struct {
-    char *name; /**< name of option */
-    void *dest; /**< pointer to the variable holding the content */
-    char *format; /**< scanf format of the data we get */
+static const struct {
+    const char *name; /**< name of option */
+    const void *dest; /**< pointer to the variable holding the content */
+    const char *format; /**< scanf format of the data we get */
     int need_alloc; /**< max memory size to be allocated for value */
-    char *comment; /**< a note to the user */
+    const char *comment; /**< a note to the user */
 } config_strings[] = {
     {
         "datadir", &options.dir_gamedata, "%1024[^\n\r]", 1025,
@@ -265,7 +265,7 @@ parse_var_value(FILE *f, int index)
         }
     } else {
         /* config_strings[].dest points to a value */
-        void *target = config_strings[i].dest;
+        const void *target = config_strings[i].dest;
 
         res = fscanf(f, format, target, &chars);
 

--- a/src/game/pace.cpp
+++ b/src/game/pace.cpp
@@ -53,9 +53,9 @@ void OpenEmUp(void)
     letter_dat = slurp_gamedat("letter.dat");
 }
 
-int PCX_D(char *src_raw, char *dest_raw, unsigned src_size)
+int PCX_D(const char *src_raw, char *dest_raw, unsigned src_size)
 {
-    char *src = (char *)src_raw;
+    const char *src = (const char *)src_raw;
     char *dest = (char *)dest_raw;
     char num;
     char *orig_dest = dest;
@@ -89,9 +89,9 @@ int PCX_D(char *src_raw, char *dest_raw, unsigned src_size)
  * \param src_size  Length of the compressed file, in bytes.
  * \return  Size of the decompressed data in bytes.
  */
-int RLED(char *src_raw, char *dest_raw, unsigned int src_size)
+int RLED(const char *src_raw, char *dest_raw, unsigned int src_size)
 {
-    signed char *src = (signed char *)src_raw;
+    const signed char *src = (const signed char *)src_raw;
     signed char *dest = (signed char *)dest_raw;
     unsigned int used;
     int count, val;
@@ -121,9 +121,10 @@ int RLED(char *src_raw, char *dest_raw, unsigned int src_size)
     return ((char *)dest - (char *)dest_raw);
 }
 
-int RLED_img(char *src_raw, char *dest_raw, unsigned int src_size, int w, int h)
+int RLED_img(const char *src_raw, char *dest_raw, unsigned int src_size,
+             int w, int h)
 {
-    signed char *src = (signed char *)src_raw;
+    const signed char *src = (const signed char *)src_raw;
     signed char *dest;
     unsigned int used;
     int count, val;
@@ -242,7 +243,7 @@ int brandom(int limit)
  * \param src_size  Length of the source contents in bytes.
  * \return  Size, in bytes, of the compressed output.
  */
-int32_t RLEC(char *src, char *dest, unsigned int src_size)
+int32_t RLEC(const char *src, char *dest, unsigned int src_size)
 {
     unsigned int src_i;
     int dest_i, cpr;
@@ -301,7 +302,7 @@ struct tblinfo {
  * \param keyname Name of the file to read from
  * \param tbl Pointer to the tblinfo to fill
  */
-void frm_read_tbl(char *keyname, struct tblinfo *tbl)
+void frm_read_tbl(const char *keyname, struct tblinfo *tbl)
 {
     FILE *fin;
     int lo, hi;
@@ -535,7 +536,7 @@ void StopVoice(void)
     av_silence(AV_SOUND_CHANNEL);
 }
 
-void PlayAudio(char *name, char mode)
+void PlayAudio(const char *name, char mode)
 {
     ssize_t bytes = 0;
     bytes = load_audio_file(name, &soundbuf, &soundbuf_size);

--- a/src/game/pace.h
+++ b/src/game/pace.h
@@ -14,13 +14,14 @@
 void delay(int millisecs);
 void FadeIn(char wh, int steps, int val, char mode);
 void FadeOut(char wh, int steps, int val, char mode);
-int PCX_D(char *src, char *dest, unsigned src_size);
+int PCX_D(const char *src, char *dest, unsigned src_size);
 int brandom(int limit);
-int RLED_img(char *src, char *dest, unsigned int src_size, int w, int h);
+int RLED_img(const char *src, char *dest, unsigned int src_size,
+             int w, int h);
 char *seq_filename(int seq, int mode);
 void idle_loop_secs(double secs);
 int getch(void);
-void PlayAudio(char *name, char mode);
+void PlayAudio(const char *name, char mode);
 char DoModem(int sel);
 void MesCenter(void);
 void StopAudio(char mode);
@@ -32,8 +33,8 @@ ssize_t load_audio_file(const char *, char **data, size_t *size);
 void idle_loop(int ticks);
 void play_audio(int sidx, int mode);
 void bzdelay(int ticks);
-int32_t RLEC(char *src, char *dest, unsigned int src_size);
-int RLED(char *src, char *dest, unsigned int src_size);
+int32_t RLEC(const char *src, char *dest, unsigned int src_size);
+int RLED(const char *src, char *dest, unsigned int src_size);
 char MPrefs(char mode);
 int bioskey(int wait);
 

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -52,7 +52,7 @@
 #include "logging.h"
 
 void BCDraw(int y);
-void DispHelp(char top, char bot, char *txt);
+void DispHelp(char top, char bot, const char *txt);
 void writePrestigeFirst(char index);
 
 
@@ -400,11 +400,10 @@ void BigHardMe(char plr, int x, int y, char hw, char unit, char sh)
 }
 
 void
-DispHelp(char top, char bot, char *txt)
+DispHelp(char top, char bot, const char *txt)
 {
-    int i, pl = 0;
-
-    i = 0;
+    int i = 0;
+    int pl = 0;
 
     while (i++ < top) {
         if (txt[i * 42] == (char) 0xcc) {

--- a/src/game/port.cpp
+++ b/src/game/port.cpp
@@ -227,7 +227,7 @@ void SpotCrap(char loc, char mode);
 void WaveFlagSetup(void);
 void WaveFlagDel(void);
 void PortPlace(FILE *fin, int32_t table);
-void PortText(int x, int y, char *txt, char col);
+void PortText(int x, int y, const char *txt, char col);
 void UpdatePortOverlays(void);
 void DoCycle(void);
 bool EndTurnOk(int plr);
@@ -237,7 +237,7 @@ void PortRestore(unsigned int Count);
 int MapKey(char plr, int key, int old) ;
 void Port(char plr);
 char PortSel(char plr, char loc);
-char Request(char plr, char *s, char md);
+char Request(char plr, const char *s, char md);
 size_t ImportPortHeader(FILE *fin, struct PortHeader &target);
 size_t ImportMOBJ(FILE *fin, MOBJ &target);
 size_t ImportSPath(FILE *fin, struct sPATH &target);
@@ -765,7 +765,7 @@ void DrawSpaceport(char plr)
     }
 }
 
-void PortText(int x, int y, char *txt, char col)
+void PortText(int x, int y, const char *txt, char col)
 {
     fill_rectangle(1, 192, 160, 198, 3);
     display::graphics.setForegroundColor(0);
@@ -1921,7 +1921,7 @@ char PortSel(char plr, char loc)
 }
 
 
-char Request(char plr, char *s, char md)
+char Request(char plr, const char *s, char md)
 {
     char i;
     display::LegacySurface local(196, 84);

--- a/src/game/records.cpp
+++ b/src/game/records.cpp
@@ -66,7 +66,7 @@ int Pict[56] = {
     317, 247, 239, 322, 291
 };
 
-char *Record_Names[56] = {
+const char *Record_Names[56] = {
     "ORBITAL SATELLITE",
     "MAN IN SPACE",
     "WOMAN IN SPACE",
@@ -126,9 +126,10 @@ char *Record_Names[56] = {
 };
 
 
-char *Months[12] = { "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-                     "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"
-                   };
+const char *Months[12] = {
+  "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+  "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"
+};
 
 int ISDOCK(int a)
 {

--- a/src/game/records.h
+++ b/src/game/records.h
@@ -45,9 +45,9 @@ extern Record_Entry rec[56][3];
 
 extern int Pict[56];
 
-extern char *Record_Names[56];
+extern const char *Record_Names[56];
 
-extern char *Months[12];
+extern const char *Months[12];
 
 
 #endif // RECORDS_H

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -112,7 +112,8 @@ done:
  * \returns nothing if it can't open the [f]seq.dat file
  */
 void
-Replay(char plr, int num, int dx, int dy, int width, int height, const char *Type)
+Replay(char plr, int num, int dx, int dy, int width, int height,
+       const char *Type)
 {
     int keep_going;
     int i, kk, mode, max;
@@ -293,7 +294,7 @@ DispBaby(int x, int y, int loc, char neww)
 
 void
 AbzFrame(char plr, int num, int dx, int dy, int width, int height,
-         char *Type, char mode)
+         const char *Type, char mode)
 {
     int idx = 0;
     struct oGROUP grp;

--- a/src/game/replay.h
+++ b/src/game/replay.h
@@ -2,7 +2,9 @@
 #define REPLAY_H
 
 void DispBaby(int x, int y, int loc, char neww);
-void AbzFrame(char plr, int num, int dx, int dy, int width, int height, char *Type, char mode);
-void Replay(char plr, int num, int dx, int dy, int width, int height, const char *Type);
+void AbzFrame(char plr, int num, int dx, int dy, int width, int height,
+              const char *Type, char mode);
+void Replay(char plr, int num, int dx, int dy, int width, int height,
+            const char *Type);
 
 #endif // REPLAY_H


### PR DESCRIPTION
Converts (most) char* variables handling string literals to be type
const char *. C++ disapproves of assigning a string literal to a mutable
char *, but allows it for backwards compatibility with C. Changes are
mostly to function arguments (such as display text, filenames, etc.),
which should be const char * for best practice anyways, and arrays of
string literals.