### PR TITLE
Fix bug in Mission Step Failure screen

### DIFF
--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -1237,13 +1237,13 @@ char FailureMode(char plr, int prelim, char *text)
 
         case 2:
             draw_string(xloc, 55, "(");
-            draw_string(0, 0, MA[Mev[STEP].pad][1].A->Name);
+            draw_string(0, 0, MA[Mev[STEP].pad][2].A->Name);
             draw_string(0, 0, ")");
             break;
 
         case 3:
             draw_string(xloc, 55, "(");
-            draw_string(0, 0, MA[Mev[STEP].pad][1].A->Name);
+            draw_string(0, 0, MA[Mev[STEP].pad][3].A->Name);
             draw_string(0, 0, ")");
             break;
         }


### PR DESCRIPTION
Correctly identify which astronaut was attempting the skill test when a
mission step fails. If the third or fourth crewmember was lending their
skill, the second crewmember would be credited.