### PR TITLE
Renamed header guards using double underscores

### DIFF
--- a/src/game/Buzz_inc.h
+++ b/src/game/Buzz_inc.h
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#ifndef __BUZZ_INC_H__
-#define __BUZZ_INC_H__ 1
+#ifndef RIS_BUZZ_INC_H
+#define RIS_BUZZ_INC_H 1
 
 extern "C" {
     int game_main(int argc, char *argv[]);
@@ -77,4 +77,4 @@ extern "C" {
 #include "macros.h"     // Collected Macros
 #include "fs.h"
 
-#endif /* __BUZZ_INC_H__ */
+#endif // RIS_BUZZ_INC_H

--- a/src/game/data.h
+++ b/src/game/data.h
@@ -1,5 +1,5 @@
-#ifndef __DATA_H__
-#define __DATA_H__
+#ifndef RIS_DATA_H
+#define RIS_DATA_H
 
 #include <stdint.h>
 
@@ -845,6 +845,6 @@ BOOST_STATIC_ASSERT(sizeof(BuzzData) == 15520);
 BOOST_STATIC_ASSERT(sizeof(MisEval) == 40);
 BOOST_STATIC_ASSERT(sizeof(Players) == 38866);
 
-#endif // __DATA_H__
+#endif // RIS_DATA_H
 
 /* vim: set noet ts=4 sw=4 tw=77: */

--- a/src/game/macros.h
+++ b/src/game/macros.h
@@ -1,6 +1,5 @@
-
-#ifndef __MACROS_H__
-#define __MACROS_H__
+#ifndef RIS_MACROS_H
+#define RIS_MACROS_H
 
 #define ARRAY_LENGTH(arr) ((sizeof (arr)) / (sizeof ((arr)[0])))
 
@@ -41,5 +40,4 @@
 #define IsHumanPlayer(a) ( (plr[(a)]==0 || plr[(a)]==1) )
 
 
-#endif
-
+#endif // RIS_MACROS_H

--- a/src/game/pace.h
+++ b/src/game/pace.h
@@ -1,5 +1,5 @@
-#ifndef __PACE_H__
-#define __PACE_H__
+#ifndef RIS_PACE_H
+#define RIS_PACE_H
 
 #include <SDL/SDL.h>
 
@@ -42,4 +42,4 @@ extern int show_intro_flag;
 extern char *letter_dat;
 
 
-#endif /* __PACE_H__ */
+#endif // RIS_PACE_H


### PR DESCRIPTION
Renamed header guards that began with underscores (ex: \_\_DATA_H\_\_)
because those are technically reserved per the C++ standard.