### PR TITLE
Skip crew selection menu when no crews available

### DIFF
--- a/src/game/crew.cpp
+++ b/src/game/crew.cpp
@@ -282,6 +282,7 @@ int AsnCrew(char plr, char pad, char part)
     } else if (count >= 8 && options.feat_no_backup > 0) {
         keyHelpText = oldKeyHelpText;
         Help("i099");
+        return 0;
     } else {
         bug = 0;
     }


### PR DESCRIPTION
Bypass the menu for assigning flight crews to a scheduled launch when
the selected capsule program does not have an available flight crew.
The player must manually cancel out of the menu since commit
395d224227511a9d14f81648022265a085c04ce6.