### PR TITLE
Workaround for compiling tests

### DIFF
--- a/test/game/downgrade_test.cpp
+++ b/test/game/downgrade_test.cpp
@@ -18,7 +18,7 @@ struct DowngradeFixture {
         mission.MissionCode = Mission_HistoricalLanding;
         mission.Patch = 29;
         mission.part = 1;
-        strcpy(mission.Hard, "ABCDE");
+        strcpy((char *) mission.Hard, "ABCDE");
         mission.Joint = 1;
         mission.Rushing = 0;
         mission.Month = 7;

--- a/test/game/mission_test.cpp
+++ b/test/game/mission_test.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(missiontype_equals_test)
     BOOST_CHECK( Equals(m1, m3) == false );
 
     m3 = m2;
-    strcpy(m3.Hard, "IJKLM");
+    strcpy((char *) m3.Hard, "IJKLM");
 
     BOOST_CHECK( Equals(m1, m3) == false );
 


### PR DESCRIPTION
Casts mission hardware to char * to allow using strcpy on it, preventing a compiler error following the introduction of JSON serialization. Fixes #656.