### PR TITLE
Fix assert failure in intel reports

### DIFF
--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -521,7 +521,8 @@ void MissionIntel(char plr, bool acc)
         mis = MissionIntelFake(plr);
     }
 
-    assert(mis >= 0 && mis <= 56 + plr);
+    // Soviet side has 57 missions (Soyuz L.L.)
+    assert(mis >= 0 && mis <= 56 + (1 ^ plr));
 
     for (int i = 0; i < Data->P[plr].PastIntel[0].cur; i++) {
         if (Data->P[plr].PastIntel[i].prog == 5 &&


### PR DESCRIPTION
Fixes a bug in the intelligence report generation, where the Soviet side can have a mission code up to 57 (56 for the U.S.) because of the Soyuz Lunar Landing. However, the code had the two sides mixed up, which could lead to a crash if the Soviet player had scheduled a Soyuz L.L. Fixes #675.