### PR TITLE
Fix manned lunar orbital being awarded to unmanned LM parking

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -364,7 +364,15 @@ void MissionSteps(char plr, int mcode, int step, int pad,
         break;
 
     case 'L':
-        Mev[step].PComp = WhichPart(plr, Mev[step].Prest = -20);
+        // Award Manned Lunar Orbital only if done by a (manned)
+        // capsule and not when parking an unmanned LM during a LOR
+        // mission
+        if (MH[pad][Mission_Capsule] != NULL) {
+            Mev[step].PComp = WhichPart(plr, Mev[step].Prest = -20);    // CAP
+        } else {
+            Mev[step].Prest = -100;
+        }
+
         break;
 
     case 'O':


### PR DESCRIPTION
Fixes a bug that awarded the manned lunar orbital prestige when the successful lunar orbital ins burn was only done by an uncrewed LM during a LOR mission but the manned capsule didn't make it. The fix checks whether the hardware of the current pad has a capsule component. Fixes #678.