### PR TITLE
PBEM snake mode

### DIFF
--- a/data/gamedata/urast.json
+++ b/data/gamedata/urast.json
@@ -22331,6 +22331,7 @@
                 "value9": 0
             }
         },
+        "Mail" : -1,
         "Mev": {
             "value0": {
                 "value0": {

--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -62,7 +62,7 @@
 #include "filesystem.h"
 #include "options.h"
 #include "prest.h"
-
+#include "pbm.h"
 
 #include <zlib.h>
 
@@ -954,7 +954,7 @@ void autosave_game(const char *name)
  * length as SaveFileHdr::Name, plus delimiter.
  *
  * \param name  The string location where the name is stored.
- * \return  the user-supplied file name, ("" if aborted).
+s * \return  the user-supplied file name, ("" if aborted).
  * \throws IOException  if insufficient disk space remaining.
  */
 std::string GetBlockName()
@@ -1603,7 +1603,6 @@ void LoadGame(const char *filename)
         LOAD = 1;
     } else if (GetSaveType(header) == SAVEGAME_PlayByMail) {
         Option = -1;
-        MAIL = !(header.Country[0] == 8);
 
         Data->plr[0] = Data->Def.Plr1 = plr[0] = 0;
         Data->plr[1] = Data->Def.Plr2 = plr[1] = 1;
@@ -1894,14 +1893,14 @@ void write_save_file(const char *Name, SaveFileHdr header)
 
     // Play-By-Mail save game hack
     //
-    // If MAIL == 0, we are playing as the U.S. We need to
+    // If MAIL_PLAYER == 0, we are playing as the U.S. We need to
     // save the game such that the U.S. starts again
-    if (MAIL == 0) {
+    if (MAIL_PLAYER == 0) {
         Data->Def.Plr1 = 8;
         Data->Def.Plr2 = 0;
     }
     // Playing as the Soviets
-    else if ((MAIL == 1)) {
+    else if ((MAIL_PLAYER == 1)) {
         Data->Def.Plr1 = 0;
         Data->Def.Plr2 = 9;
     }

--- a/src/game/data.h
+++ b/src/game/data.h
@@ -851,11 +851,12 @@ struct Players {
     int8_t Season;                  /**< Season of Year */
     struct PrestType Prestige[MAXIMUM_PRESTIGE_NUM];   /**< Definitions of Prest Vals */
     struct BuzzData P[NUM_PLAYERS];  /**< Player Game Data */
-    int8_t unused_EMark[4]           ; /**< unused - Event Marker */
+    int8_t unused_EMark[3]           ; /**< unused - Event Marker */
     int8_t Events[MAXIMUM_NEWS_EVENTS]; /**< History of Event Cards */
     int8_t Count;                      /**< Number of Events Picked */
     int8_t PD[NUM_PLAYERS][MAXIMUM_PRESTIGE_NUM]; /**< Prestige First Displayed: First Bit: Seen in MisRev, Second Bit: Seen by Opponent */
     int8_t Mile[NUM_PLAYERS][10];      /**< MileStone Calcs */
+    int8_t Mail;                       /* Current status of PBEM game */
     struct MisEval Mev[MAX_LAUNCHPADS][60]; /** < Mission eval for mail games */
     int8_t Step[MAX_LAUNCHPADS]; /** Number of mission steps for mail games */
 
@@ -875,6 +876,9 @@ struct Players {
         ar(CEREAL_NVP(Count));
         ar(CEREAL_NVP(PD));
         ar(CEREAL_NVP(Mile));
+        if (version > 0) {
+            ar(CEREAL_NVP(Mail));
+        }
         ar(CEREAL_NVP(Mev));
         ar(CEREAL_NVP(Step));
 
@@ -884,6 +888,8 @@ struct Players {
         ASSERT(Season == 0 || Season == 1);
     }
 };
+
+CEREAL_CLASS_VERSION(struct Players, 1)
 
 struct MisAst {  // This struct will be -1's if empty
     struct Astros *A;

--- a/src/game/endgame.cpp
+++ b/src/game/endgame.cpp
@@ -46,6 +46,7 @@
 #include "pace.h"
 #include "endianness.h"
 #include "filesystem.h"
+#include "pbm.h"
 
 
 char PF[29][40] = {

--- a/src/game/game_main.h
+++ b/src/game/game_main.h
@@ -18,7 +18,6 @@ void PauseMouse(void);
 void GetMouse_fast(void);
 
 extern char Option;
-extern char MAIL;
 extern int fOFF;
 extern char AI[2];
 extern char manOnMoon;

--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -48,6 +48,7 @@
 #include "filesystem.h"
 #include "randomize.h"
 #include "data.h"
+#include "pbm.h"
 
 Equipment *MH[2][8];   // Pointer to the hardware
 struct MisAst MA[2][4];  //[2][4]
@@ -120,8 +121,8 @@ int Launch(char plr, char mis)
     STEP = FINAL = JOINT = PastBANG = 0;
     MisStat = tMen = 0x00; // clear mission status flags
 
-    // Don't do U.S. missions twice, just update prestige data
-    if (MAIL == 1 && plr == 0) {
+    // Don't do missions twice, just update prestige data
+    if ((MAIL == 1 && plr == 0) || (MAIL == 2 && plr == 1)) {
         STEPnum = Data->Step[mis];
         memcpy(Mev, Data->Mev[mis], 60 * sizeof(struct MisEval));
         // Check for Mission death
@@ -350,7 +351,7 @@ int Launch(char plr, char mis)
 
 //   if (!AI[plr]) KillMusic();
 
-    if (MAIL == 0) {
+    if (MAIL == 0 || MAIL == 3) {
         Data->Step[mis] = STEPnum;
     }
 
@@ -373,7 +374,7 @@ int Launch(char plr, char mis)
         }
     }
 
-    if (MAIL == 0) {
+    if (MAIL == 0 || MAIL == 3) {
         memcpy(Data->Mev[mis], Mev, 60 * sizeof(struct MisEval));
     }
 

--- a/src/game/newmis.cpp
+++ b/src/game/newmis.cpp
@@ -119,7 +119,7 @@ OrderMissions(void)
     for (i = 0; i < NUM_PLAYERS; i++) {
         for (j = 0; j < MAX_MISSIONS; j++) {
             // Don't run the Soviet missions during the U.S. turn
-            if (!(MAIL_PLAYER == 0 && i == MAIL_OPPONENT)) {
+            if (!((MAIL == 0 && i == 1) || (MAIL == 3 && i == 0))) {
                 if (Data->P[i].Mission[j].MissionCode
                     && Data->P[i].Mission[j].part != 1) {
                     Order[k].plr = i;

--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -862,7 +862,16 @@ News(char plr)
 void
 AIEvent(char plr)
 {
+    int turn = 2 * (Data->Year - 57) + Data->Season + 1;  // start at turn 1
+    bool freshNews = (turn > Data->P[plr].eCount);
+
     ResolveEvent(plr);
+
+    // Do not update event counter when loading saved game
+    if (freshNews) {
+        Data->P[plr].eCount++;
+        assert(Data->P[plr].eCount < MAX_NEWS_ITEMS / 2);
+    }
 }
 
 // ResolveEvent seems to set a flag in the BadCard array

--- a/src/game/pbm.cpp
+++ b/src/game/pbm.cpp
@@ -60,16 +60,36 @@ void ShowPrestigeResults(char plr)
     }
 }
 
-/* Updates the MAIL variable for the next player and saves the current
- * game. Only fades out if the game is not a PBEM game.
+/* Saves the current game. Only fades out if the game is not a PBEM
+ * game.
  */
 void MailSwitchPlayer(void)
 {
-    MAIL = MAIL_NEXT;
-
     if (MAIL != -1) {
         FileAccess(2);
     }
 
     FadeOut(2, 10, 0, 0);
+}
+
+/* Immediately hand over to the other player during the endgame. MAIL
+   must be either 1 or 2 to show endgame. */
+void MailSwitchEndgame(void)
+{
+    switch (MAIL) {
+    case 0:
+      MAIL = 1;
+      break;
+    case 1:
+      MAIL = 2;
+      break;
+    case 2:
+      MAIL = 1;
+      break;
+    case 3:
+      MAIL = 2;
+      break;
+    }
+                                
+    MailSwitchPlayer();
 }

--- a/src/game/pbm.h
+++ b/src/game/pbm.h
@@ -1,11 +1,20 @@
 #ifndef PBM_H
 #define PBM_H
 
-#define MAIL_OPPONENT (MAIL == -1 ? -1 : MAIL ^ 1)
-#define MAIL_PLAYER (MAIL)
-#define MAIL_NEXT (MAIL == -1 ? -1 : MAIL ^ 1)
+#define MAIL (Data->Mail)
+
+// First bit of MAIL: player (0: U.S., 1; Soviet)
+// Second bit: turn order (0: first U.S., 1: first Soviet (i.e., inverted))
+#define MAIL_PLAYER (MAIL % 2)
+#define MAIL_INVERTED ((MAIL & 2) >> 1)
+
+#define MAIL_OPPONENT (MAIL == -1 ? -1 : MAIL_PLAYER ^ 1)
+
+// order is 0 1 3 2 0 ...
+#define MAIL_NEXT (MAIL == -1 ? -1 : (2 * MAIL + 1 - MAIL / 2) % 4)
 
 void ShowPrestigeResults(char plr);
 void MailSwitchPlayer();
+void MailSwitchEndgame(void);
 
 #endif //PBM_H

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -50,6 +50,7 @@
 #include "filesystem.h"
 #include "ioexception.h"
 #include "logging.h"
+#include "pbm.h"
 
 void BCDraw(int y);
 void DispHelp(char top, char bot, const char *txt);
@@ -863,7 +864,7 @@ void Draw_Mis_Stats(char plr, char index, int *where, char mode)
 
     draw_string(12, 112, "PRESTIGE EARNED: ");
 
-    if ((MAIL != 0 && Option == -1) || mode == 0) {
+    if ((MAIL != 0 && MAIL != 3 && Option == -1) || mode == 0) {
         draw_number(0, 0, Data->P[plr].History[index].Prestige);
     } else {
         draw_string(0, 0, "PENDING");

--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -468,7 +468,7 @@ char Set_Goal(char plr, char which, char control)
                 Data->P[plr].MissionCatastrophicFailureOnTurn |= 4;  // for astros
 
 
-                if (MAIL == 0) {
+                if (MAIL == 0 || MAIL == 3) {
                     pd = Mev[0].pad;
                     qt = Data->P[0].Udp[pd].Qty;
                     Data->P[0].Udp[pd].HInd = Data->P[0].PastMissionCount;
@@ -494,7 +494,7 @@ char Set_Goal(char plr, char which, char control)
                 case Prestige_Duration_D:
                 case Prestige_Duration_E:
                 case Prestige_Duration_F:
-                    if (MAIL == 0) {
+                    if (MAIL == 0 || MAIL == 3) {
                         pd = Mev[0].pad;
                         qt = Data->P[0].Udp[pd].Qty;
                         Data->P[0].Udp[pd].HInd = Data->P[0].PastMissionCount;
@@ -874,7 +874,7 @@ int AllotPrest(char plr, char mis)
     negs = 0;
 
     // PHOTO RECON; don't increase twice in mail games
-    if (!(MAIL == 1 && plr == 0)) {
+    if (!((MAIL == 1 && plr == 0) || (MAIL == 2 && plr == 1))) {
         if (PVal[Prestige_MannedLunarPass] > 0 && PVal[Prestige_MannedLunarPass] < 4) {
             Data->P[plr].Misc[MISC_HW_PHOTO_RECON].Safety += 5;    // manned stuff gets 5
         }
@@ -917,7 +917,7 @@ int AllotPrest(char plr, char mis)
     }
 
     // Don't increase docking safety twice in mail games
-    if (!(MAIL == 1 && plr == 0)) {
+    if (!((MAIL == 1 && plr == 0) || (MAIL == 2 && plr == 1))) {
         if (Check_Dock(500) == 2) {  // Success
             Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety += 10;
             Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety = MIN(Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].Safety, Data->P[plr].Misc[MISC_HW_DOCKING_MODULE].MaxSafety);
@@ -1067,7 +1067,7 @@ int AllotPrest(char plr, char mis)
     }
 
     // LM POINTS; don't add them twice in mail games
-    if (!(MAIL == 1 && plr == 0)) {
+    if (!((MAIL == 1 && plr == 0) || (MAIL == 2 && plr == 1))) {
         Set_LM(plr, STEPnum);
 
         if (mcode >= 48 && mcode <= 52 && other < 3000) {
@@ -1144,7 +1144,7 @@ int U_AllotPrest(char plr, char mis)
     lun = Check_Photo();
 
     // Don't improve photo recon twice in mail games
-    if (MAIL == 1 && plr == 0) {
+    if ((MAIL == 1 && plr == 0) || (MAIL == 2 && plr == 1)) {
         lun = 0;
     }
 
@@ -1251,13 +1251,13 @@ int Update_Prestige_Data(char plr, char mis, int code)
     Data->P[plr].Prestige += total;
     Data->P[plr].History[Data->P[plr].PastMissionCount].Prestige = total;
 
-    if (MAIL == 1 && plr == MAIL_OPPONENT) {
+    if ((MAIL == 1 && plr == 0) || (MAIL == 2 && plr == 1)) {
         Data->P[plr].PastMissionCount++; // Normally done in MissionPast()
         assert(Data->P[plr].PastMissionCount < MAX_MISSION_COUNT);
     }
 
-    // Player prestige gets updated after the Soviet turn
-    if (MAIL != 0) {
+    // Player prestige is delayed in mail games
+    if (MAIL != 0 && MAIL != 3) {
         Data->P[plr].Prestige += total;
     }
 


### PR DESCRIPTION
Changes the turn order for PBEM games to AB|BA|AB|B..., where A=U.S. and B=Soviet and the vertical bar denotes the end of the turn. This has two advantages:

1. Latency is cut in half because you can play two turns in a row without having to wait for the other player to respond.
2. Evenly balances the advantage to be able to make a last minute scrub depending on the other player's prestige firsts.