### PR TITLE
Fix buffer overflow caused by PBEM autosave

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -944,6 +944,10 @@ void autosave_game(const char *name)
 
     write_save_file(name, hdr);
 
+    // Repair data modified by save
+    Data->plr[0] = Data->Def.Plr1 = plr[0] = 0;
+    Data->plr[1] = Data->Def.Plr2 = plr[1] = 1;
+
 }
 
 


### PR DESCRIPTION
Fixes an error when autosaving in PBEM games which led to some data used for array indexing containing unsafe values. This could lead to a buffer overflow showing strange behavior in the Preferences screen.