### PR TITLE
Fix awarding of capsule prestige points in PBEM games

### DIFF
--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -134,6 +134,9 @@ int Launch(char plr, char mis)
             death = 0;
         }
 
+        MANNED[0] = Data->P[plr].Mission[mis].Men;
+        MANNED[1] = Data->P[plr].Mission[mis].Joint ? Data->P[plr].Mission[mis + 1].Men : 0;
+
         return Update_Prestige_Data(
                    plr, mis, Data->P[plr].Mission[mis].MissionCode);
     }


### PR DESCRIPTION
Fixes an error in the awarding of prestige prestige for capsule firsts that were not properly recorded in PBEM games.