### PR TITLE
Fix PBEM regressions

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -945,8 +945,8 @@ void autosave_game(const char *name)
     write_save_file(name, hdr);
 
     // Repair data modified by save
-    Data->plr[0] = Data->Def.Plr1 = plr[0] = 0;
-    Data->plr[1] = Data->Def.Plr2 = plr[1] = 1;
+    Data->plr[0] = Data->Def.Plr1 = plr[0] = 2*AI[0];
+    Data->plr[1] = Data->Def.Plr2 = plr[1] = 1 + 2*AI[1];
 
 }
 

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -646,7 +646,7 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
             // Only increase the global event counter if this is really a new
             // turn and not one already played in a save game
             if(Data->Count == 2 * (2 * (Data->Year - 57) + Data->Season)
-               + MAIL_INVERTED == 1 ? 1^i : i) {
+               + (MAIL_INVERTED == 1 ? 1^i : i)) {
                 Data->Count++;
             }
 


### PR DESCRIPTION
Fixes two regressions introduced by improper fixes for PBEM bugs. One led to the crash of games played against the computer due to improper values for the plr[] array, the other prevented the event data from being correctly filled. Fixes #702.