### PR TITLE
Allow current player to change name in preferences

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -254,7 +254,7 @@ void Admin(char plr)
             music_stop();
             helpText = "i013";
             keyHelpText = "k013";
-            Prefs(1);
+            Prefs(1, plr);
             key = 0;
             break;
 

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -269,12 +269,12 @@ int game_main_impl(int argc, char *argv[])
             helpText = "i013";
 
             if (MAIL == -1) {
-                Prefs(0);                     // GET INITIAL PREFS FROM PLAYER
+                Prefs(0, -1);                  // GET INITIAL PREFS FROM PLAYER
             }
 
 #ifdef ALLOW_PBEM
             else { // MAIL GAME
-                Prefs(3);
+                Prefs(3, -1);
             }
 
 #endif // ALLOW_PBEM

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -342,7 +342,7 @@ void CLevels(char side, char wh, DisplayContext &dctx)
  *
  * \param where  0 for pregame setup, 1 for in-game settings, 3 for mail game
  */
-void Prefs(int where)
+void Prefs(int where, int player)
 {
     int num, hum1 = 0, hum2 = 0;
     FILE *fin;
@@ -618,8 +618,8 @@ void Prefs(int where)
 
                 Levels(1, Data->Def.Ast2, 0, dctx);
                 /* P2: Astro Level */
-            } else if ((x >= 6 && y >= 34 && x <= 83 && y <= 42 && (where == 3 || where == 0) && mousebuttons > 0) ||
-                       ((where == 3 || where == 0) && ksel == 0 && key == 'N')) {
+            } else if ((x >= 6 && y >= 34 && x <= 83 && y <= 42 && (where == 3 || where == 0 || (where == 1 && player == 0)) && mousebuttons > 0) ||
+                       ((where == 3 || where == 0 || (where == 1 && player == 0)) && ksel == 0 && key == 'N')) {
                 fill_rectangle(7, 35, 82, 41, 0);
 
                 for (int i = 0; i < 20; i++) {
@@ -663,8 +663,8 @@ void Prefs(int where)
                 draw_string(8, 40, &Data->P[0].Name[0]);
                 av_sync();
                 /* P1: Director Name */
-            } else if ((x >= 236 && y >= 34 && x <= 313 && y <= 42 && (where == 3 || where == 0) && mousebuttons > 0) ||
-                       ((where == 3 || where == 0) && ksel == 1 && key == 'N')) {
+            } else if ((x >= 236 && y >= 34 && x <= 313 && y <= 42 && (where == 3 || where == 0 || (where == 1 && player == 1)) && mousebuttons > 0) ||
+                       ((where == 3 || where == 0 || (where == 1 && player == 1)) && ksel == 1 && key == 'N')) {
                 fill_rectangle(237, 35, 312, 41, 0);
 
                 for (int i = 0; i < 20; i++) {

--- a/src/game/prefs.h
+++ b/src/game/prefs.h
@@ -1,6 +1,6 @@
 #ifndef PREFS_H
 #define PREFS_H
 
-void Prefs(int where);
+void Prefs(int where, int player);
 
 #endif // PREFS_H


### PR DESCRIPTION
Allows the current player to change their name in the preferences screen even when the game is already running. Fixes #591.