### PR TITLE
Fix crash when starting a PBEM game after playing the Soviets

### DIFF
--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -297,6 +297,9 @@ int game_main_impl(int argc, char *argv[])
                     AI[1] = 0;
                 }
             }
+            else {
+                AI[0] = AI[1] = 0;
+            }
 
             InitData();                   // PICK EVENT CARDS N STUFF
             MainLoop();                   // PLAY GAME


### PR DESCRIPTION
Fixes a bug in the initialization of PBEM games that caused AI flags not being reset from a previous game, leading to a crash if the previous game had the U.S. side being played by the computer.