### PR TITLE
Fix duration calculation on joint duration missions

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -928,6 +928,9 @@ int AllotPrest(char plr, char mis)
 
     // DURATION FIRSTS
     Data->P[plr].Mission[mis].Duration = MAX(Data->P[plr].Mission[mis].Duration, 1);
+    if (Data->P[plr].Mission[mis].Joint) {
+        Data->P[plr].Mission[mis].Duration = MAX(Data->P[plr].Mission[mis].Duration, Data->P[plr].Mission[mis + 1].Duration);
+    }
 
     if (!misType.Dur) {
         switch (P_Goal) {


### PR DESCRIPTION
Fixes a bug with the duration calculation on joint missions, where duration steps run on the second pad (usually, only the second pad is manned on joint launches) were not properly counted. Fixes #690.