### PR TITLE
Delinks hardware SMods and Damage

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -838,8 +838,7 @@ void MissionSetup(char plr, char mis)
                 }
 
                 if (eq != NULL) {
-                    eq->SMods = eq->Damage;  //Damaged Equipment, Nikakd, 10/8/10 - changed from eq->SMods += eq->Damage 2/11/23 to fix #737 LPB
-                    eq->MisSaf = eq->Safety + eq->SMods;
+                    eq->MisSaf = eq->Safety + eq->SMods + eq->Damage;
 
                     if (eq->ID[1] >= 0x35 && i == Mission_LM &&
                         Data->P[plr].Mission[mis].MissionCode >= 53) {


### PR DESCRIPTION
Calculates hardware mission safety stats (MisSaf) off of both Smods and Damage rather than modifying Smods with Damage. This retains fix added by b258b1d without blanking Smods (leaving it available for future use).