### PR TITLE
Fix prestige handling on alternate branch

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -789,7 +789,8 @@ int AllotPrest(char plr, char mis)
     other = MaxFail();
 
     for (i = 0; Mev[i].trace != 0x7F; i = Mev[i].trace) {
-        if (Mev[i].PComp == 5 && Mev[i].StepInfo == 0) {
+        // PComp == 5 means alternate branch
+        if (Mev[i].PComp == 5) {
             Mev[i].PComp = 0;
             Mev[i].Prest = -100;
         }


### PR DESCRIPTION
Fixes an issue with the prestige handling on an alternate branch that could lead the prestige awarded for previously successful steps being overwritten (like the lunar EVA being invalidated by a later emergency EVA). Fixes #741.