### PR TITLE
Fix missing videos

### DIFF
--- a/data/gamedata/seq.json
+++ b/data/gamedata/seq.json
@@ -4087,6 +4087,56 @@
     "audio": [ "STAT_00", "NONE", "NONE","NONE","NONE" ]
   },
   {
+    "MissionIdSequence": "UTCP",
+    "video": [ "USCAP", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "UTLM",
+    "video": [ "USLMTST", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "UTEV",
+    "video": [ "USEVA", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "UTDO",
+    "video": [ "UDOCK", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "UTDU",
+    "video": [ "UCENTRI", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "STCP",
+    "video": [ "SJETS", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "STLM",
+    "video": [ "SVLEM", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "STEV",
+    "video": [ "SVEVA", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "STDO",
+    "video": [ "SDOCK", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
+    "MissionIdSequence": "STDU",
+    "video": [ "SCENTRI", "NONE", "NONE","NONE","NONE" ],
+    "audio": [ "NONE", "NONE", "NONE","NONE","NONE" ]
+  },
+  {
     "MissionIdSequence": "XXXXXXXX",
     "video": [ "XXXXXX", "XXXXXX", "XXXXXX","XXXXXX","XXXXXX" ],
     "audio": [ "XXXXXX", "XXXXXX", "XXXXXX","XXXXXX","XXXXXX" ]

--- a/src/game/endgame.cpp
+++ b/src/game/endgame.cpp
@@ -591,7 +591,8 @@ void NewEnd(char win, char loc)
             ShBox(149, 9, 309, 100);
             InBox(153, 13, 305, 96);
             music_start(M_PRGMTRG);
-            Replay(win, 0, 154, 14, 149, 82, (win == 0) ? "UPAR" : "SPAR");
+            // TODO: Sequence variation for the parade
+            Replay(win, 0, 154, 14, 149, 82, (win == 0) ? "310UPAR" : "520SPAR");
             music_stop();
             helpText = "i144";
             keyHelpText = "k044";
@@ -621,7 +622,8 @@ void NewEnd(char win, char loc)
             ShBox(149, 9, 309, 100);
             InBox(153, 13, 305, 96);
             music_start(M_MISSPLAN);
-            Replay(win, 0, 154, 14, 149, 82, (win == 0) ? "PUM3C6" : "PSM3C6");
+            // TODO: show the actual lunar EVA
+            Replay(win, 0, 154, 14, 149, 82, (win == 0) ? "520PUM3C6" : "121PSM3C6");
             music_stop();
             helpText = "i144";
             keyHelpText = "k044";

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -43,14 +43,21 @@ LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT)
 
 void
 Replay(char plr, int num, int dx, int dy, int width, int height,
-       const char *Type)
+       std::string Type)
 {
     int keep_going;
     int i, j, kk, mode, max;
     int32_t offset;
-    std::vector <REPLAY> Rep = interimData.tempReplay.at((plr * 100) + num);
+    std::vector <REPLAY> Rep;
     std::vector<struct MissionSequenceKey> sSeq, fSeq;
     char *fname;
+
+    if (Type == "0000") {
+        Rep = interimData.tempReplay.at((plr * 100) + num);
+    }
+    else {
+        Rep.push_back({false, Type});
+    }
 
     mm_file vidfile;
     float fps;

--- a/src/game/replay.h
+++ b/src/game/replay.h
@@ -1,10 +1,12 @@
 #ifndef REPLAY_H
 #define REPLAY_H
 
+#include <string>
+
 void DispBaby(int x, int y, int loc, char neww);
 void AbzFrame(char plr, int num, int dx, int dy, int width, int height,
               const char *Type, char mode);
 void Replay(char plr, int num, int dx, int dy, int width, int height,
-            const char *Type);
+            std::string Type);
 
 #endif // REPLAY_H


### PR DESCRIPTION
#749 caused the videos for the 'naut training and the endgame videos (parade and lunar EVA) not being shown anymore.

Includes training videos into fseq.json, so that they can be shown in the respective training screen. Modifies the code for the display of the parade and the lunar EVA in the endgame screen so that they find the correct sequence.