### PR TITLE
Fix launch abort sequence for B/TITAN+XMS2

### DIFF
--- a/data/gamedata/fseq.json
+++ b/data/gamedata/fseq.json
@@ -1810,13 +1810,13 @@
   {
     "MissionStep": "F100",
     "MissionIdSequence": "110AUR500",
-    "video": [ "TTBL_01", "NONE", "NONE","NONE","NONE" ],
+    "video": [ "PPIX_07", "NONE", "NONE","NONE","NONE" ],
     "audio": [ "RNG6_00", "NONE", "NONE","NONE","NONE" ]
   },
   {
     "MissionStep": "F100",
     "MissionIdSequence": "110AUR505",
-    "video": [ "TTBL_01", "NONE", "NONE","NONE","NONE" ],
+    "video": [ "PPIX_07", "NONE", "NONE","NONE","NONE" ],
     "audio": [ "RNG6_00", "NONE", "NONE","NONE","NONE" ]
   },
   {


### PR DESCRIPTION
Replaces the explosion shown for pre-liftoff aborts for the XMS2 on a boosted Titan by the proper animation. Fixes #740.