### PR TITLE
Store mission equipment successes and failures by pad

### DIFF
--- a/data/gamedata/urast.json
+++ b/data/gamedata/urast.json
@@ -7,7 +7,7 @@
             "value2": 76,
             "value3": 79
         },
-        "Checksum": 38866,
+        "Checksum": 38978,
         "plr": {
             "value0": 0,
             "value1": 0

--- a/src/game/data.h
+++ b/src/game/data.h
@@ -276,8 +276,8 @@ struct Equipment {
     int8_t Duration;      /**< Days it can last in space */
     int8_t Damage;        /**< Damage percent for next launch */
     int8_t DCost;         /**< Cost to repair damage */
-    int8_t MisSucc;       /**< Mission Successes */
-    int8_t MisFail;       /**< Mission Failures */
+    int8_t MisSucc[2];       /**< Mission Successes */
+    int8_t MisFail[2];       /**< Mission Failures */
 
     template<class Archive>
     void serialize(Archive &ar, uint32_t const version)
@@ -312,8 +312,6 @@ struct Equipment {
         ar(CEREAL_NVP(Duration));
         ar(CEREAL_NVP(Damage));
         ar(CEREAL_NVP(DCost));
-        ar(CEREAL_NVP(MisSucc));
-        ar(CEREAL_NVP(MisFail));
     }
 
 };
@@ -1321,13 +1319,13 @@ CEREAL_CLASS_VERSION(INTERIMDATA, 1);
 // Errors in these lines mean that the struct is the wrong shape
 #include <boost/static_assert.hpp>
 BOOST_STATIC_ASSERT(sizeof(PrestType) == 15);
-BOOST_STATIC_ASSERT(sizeof(Equipment) == 58);
+BOOST_STATIC_ASSERT(sizeof(Equipment) == 60);
 BOOST_STATIC_ASSERT(sizeof(MissionType) == 43);
 BOOST_STATIC_ASSERT(sizeof(Astros) == 63);
 BOOST_STATIC_ASSERT(sizeof(PastInfo) == 84);
-BOOST_STATIC_ASSERT(sizeof(BuzzData) == 15520);
+BOOST_STATIC_ASSERT(sizeof(BuzzData) == 15576);
 BOOST_STATIC_ASSERT(sizeof(MisEval) == 40);
-BOOST_STATIC_ASSERT(sizeof(Players) == 38866);
+BOOST_STATIC_ASSERT(sizeof(Players) == 38978);
 
 #endif // RIS_DATA_H
 

--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -886,11 +886,11 @@ void MissionSetDown(char plr, char mis)
 
     for (j = 0; j < (Data->P[plr].Mission[mis].Joint + 1); j++) {
         for (i = 0; i < 7; i++) {  // Ignore Boosters
-            if (MH[j][i] != NULL && (MH[j][i]->MisSucc > 0 || MH[j][i]->MisFail > 0)) {
+            if (MH[j][i] != NULL && (MH[j][i]->MisSucc[j] > 0 || MH[j][i]->MisFail[j] > 0)) {
 
                 MH[j][i]->SMods = MH[j][i]->Damage = MH[j][i]->DCost = 0;
 
-                if (strncmp(MH[j][i]->Name, (i == Mission_Probe_DM) ? "DOC" : "PHO", 3) != 0 && MH[j][i]->MisSucc > 0) {
+                if (strncmp(MH[j][i]->Name, (i == Mission_Probe_DM) ? "DOC" : "PHO", 3) != 0 && MH[j][i]->MisSucc[j] > 0) {
                     MH[j][i]->Safety = MIN(MH[j][i]->Safety + 1, MH[j][i]->MaxSafety);
 
                     if (options.cheat_addMaxS) {
@@ -902,26 +902,26 @@ void MissionSetDown(char plr, char mis)
                     }
                 }
 
-                if (strncmp(MH[j][i]->Name, "DOC", 3) == 0 && (MH[j][i]->MisFail + MH[j][i]->MisSucc) == 0) {
-                    MH[j][i]->MisFail = 1;
+                if (strncmp(MH[j][i]->Name, "DOC", 3) == 0 && (MH[j][i]->MisFail[j] + MH[j][i]->MisSucc[j]) == 0) {
+                    MH[j][i]->MisFail[j] = 1;
                 }
 
-                if ((MH[j][i]->MisFail + MH[j][i]->MisSucc) == 0 && (strncmp(MH[j][i]->ID, "M3", 2) != 0)) {
-                    MH[j][i]->MisFail++;
+                if ((MH[j][i]->MisFail[j] + MH[j][i]->MisSucc[j]) == 0 && (strncmp(MH[j][i]->ID, "M3", 2) != 0)) {
+                    MH[j][i]->MisFail[j]++;
                 }
 
-                if ((MH[j][i]->MisFail + MH[j][i]->MisSucc) == 0 && MH[j][i]->ID[0] == 'P') {
-                    MH[j][i]->MisFail++;
+                if ((MH[j][i]->MisFail[j] + MH[j][i]->MisSucc[j]) == 0 && MH[j][i]->ID[0] == 'P') {
+                    MH[j][i]->MisFail[j]++;
                 }
 
 
-                MH[j][i]->Failures += MH[j][i]->MisFail;
+                MH[j][i]->Failures += MH[j][i]->MisFail[j];
 
-                MH[j][i]->Steps += (MH[j][i]->MisFail + MH[j][i]->MisSucc);
+                MH[j][i]->Steps += (MH[j][i]->MisFail[j] + MH[j][i]->MisSucc[j]);
 
                 if (i == Mission_PrimaryBooster &&
                     MH[j][Mission_SecondaryBooster] != NULL) {  // Boosters
-                    if (MH[j][Mission_PrimaryBooster]->MisSucc > 0)  {
+                    if (MH[j][Mission_PrimaryBooster]->MisSucc[j] > 0)  {
                         MH[j][Mission_SecondaryBooster]->Safety =
                             MIN(MH[j][Mission_SecondaryBooster]->Safety + 1,
                                 MH[j][Mission_SecondaryBooster]->MaxSafety);
@@ -940,15 +940,15 @@ void MissionSetDown(char plr, char mis)
                     MH[j][Mission_SecondaryBooster]->DCost = 0;
 
                     MH[j][Mission_SecondaryBooster]->Failures +=
-                        MH[j][Mission_PrimaryBooster]->MisFail;
+                        MH[j][Mission_PrimaryBooster]->MisFail[j];
                     MH[j][Mission_SecondaryBooster]->Steps +=
-                        (MH[j][Mission_PrimaryBooster]->MisFail +
-                         MH[j][Mission_PrimaryBooster]->MisSucc);
-                    MH[j][Mission_SecondaryBooster]->MisSucc = 0;
-                    MH[j][Mission_SecondaryBooster]->MisFail = 0;
+                        (MH[j][Mission_PrimaryBooster]->MisFail[j] +
+                         MH[j][Mission_PrimaryBooster]->MisSucc[j]);
+                    MH[j][Mission_SecondaryBooster]->MisSucc[j] = 0;
+                    MH[j][Mission_SecondaryBooster]->MisFail[j] = 0;
                 }
 
-                MH[j][i]->MisSucc = MH[j][i]->MisFail = 0;
+                MH[j][i]->MisSucc[j] = MH[j][i]->MisFail[j] = 0;
             }  // if
         }  // for i
 

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -485,7 +485,7 @@ void MisCheck(char plr, char mpad)
             }
 
             if (!(strncmp(GetEquipment(Mev[STEP])->Name, "DO", 2) == 0 && Mev[STEP].loc == 0x02)) {
-                GetEquipment(Mev[STEP])->MisSucc++;  // set for all but docking power on
+                GetEquipment(Mev[STEP])->MisSucc[Mev[STEP].pad]++;  // set for all but docking power on
             }
 
             Mev[STEP].StepInfo = 1;
@@ -830,7 +830,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
     temp = 0; /* XXX check uninitialized */
 
     if (!(strncmp(GetEquipment(Mev[STEP])->Name, "DO", 2) == 0 && Mev[STEP].loc == 0x02)) {
-        GetEquipment(Mev[STEP])->MisFail++;  // set failure for all but docking power on
+        GetEquipment(Mev[STEP])->MisFail[Mev[STEP].pad]++;  // set failure for all but docking power on
     }
 
     Mev[STEP].StepInfo = 1003;
@@ -849,7 +849,7 @@ int FailEval(char plr, int type, char *text, int val, int xtra)
 
         // Special Case for PhotoRecon with Lunar Probe
         if (Mev[STEP].loc == 20 && mcc == Mission_Lunar_Probe) {
-            GetEquipment(Mev[STEP - 1])->MisFail++;
+            GetEquipment(Mev[STEP - 1])->MisFail[Mev[STEP].pad]++;
         }
 
         return 0;


### PR DESCRIPTION
Changes the equipment data structure to store the number of successful steps and failures independently for different pads. This enables awarding two additional safety points for pieces of equipment that are present in both pads. Fixes #328.