### PR TITLE
Remove redundant code

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -173,37 +173,8 @@ void Admin(char plr)
         if (beg) {
             beg = 0;
         } else {
-
             FadeOut(2, 10, 0, 0);
-
             DrawSpaceport(plr);
-            PortPal(plr);
-            fill_rectangle(166, 191, 318, 198, 3);
-            display::graphics.setForegroundColor(0);
-            draw_string(257, 197, "CASH:");
-            draw_megabucks(285, 197, Data->P[plr].Cash);
-            display::graphics.setForegroundColor(11);
-            draw_string(256, 196, "CASH:");
-            draw_megabucks(284, 196, Data->P[plr].Cash);
-            display::graphics.setForegroundColor(0);
-
-            if (Data->Season == 0) {
-                draw_string(166, 197, "SPRING 19");
-            } else {
-                draw_string(166, 197, "FALL 19");
-            }
-
-            draw_number(0, 0, Data->Year);
-            display::graphics.setForegroundColor(11);
-
-            if (Data->Season == 0) {
-                draw_string(165, 196, "SPRING 19");
-            } else {
-                draw_string(165, 196, "FALL 19");
-            }
-
-            draw_number(0, 0, Data->Year);
-
             FadeIn(2, 10, 0, 0);
         }
 

--- a/src/game/intel.cpp
+++ b/src/game/intel.cpp
@@ -364,37 +364,9 @@ void Intel(char plr)
         if (beg) {
             beg = 0;
         } else {
-
             FadeOut(2, 10, 0, 0);
             DrawSpaceport(plr);
-            PortPal(plr);
-            fill_rectangle(166, 191, 318, 198, 3);
-            display::graphics.setForegroundColor(0);
-            draw_string(257, 197, "CASH:");
-            draw_megabucks(285, 197, Data->P[plr].Cash);
-            display::graphics.setForegroundColor(11);
-            draw_string(256, 196, "CASH:");
-            draw_megabucks(284, 196, Data->P[plr].Cash);
-            display::graphics.setForegroundColor(0);
-
-            if (Data->Season == 0) {
-                draw_string(166, 197, "SPRING 19");
-            } else {
-                draw_string(166, 197, "FALL 19");
-            }
-
-            draw_number(0, 0, Data->Year);
-            display::graphics.setForegroundColor(11);
-
-            if (Data->Season == 0) {
-                draw_string(165, 196, "SPRING 19");
-            } else {
-                draw_string(165, 196, "FALL 19");
-            }
-
-            draw_number(0, 0, Data->Year);
             FadeIn(2, 10, 0, 0);
-
         }
 
         helpText = (plr == 0) ? "i704" : "i705";

--- a/src/game/museum.cpp
+++ b/src/game/museum.cpp
@@ -162,35 +162,7 @@ void Museum(char plr)
             beg = (Data->P[plr].AstroCount > 0) ? 7 : 6;    // mods for astros
         } else {
             FadeOut(2, 10, 0, 0);
-
             DrawSpaceport(plr);
-            PortPal(plr);
-            fill_rectangle(166, 191, 318, 198, 3);
-            display::graphics.setForegroundColor(0);
-            draw_string(257, 197, "CASH:");
-            draw_megabucks(285, 197, Data->P[plr].Cash);
-            display::graphics.setForegroundColor(11);
-            draw_string(256, 196, "CASH:");
-            draw_megabucks(284, 196, Data->P[plr].Cash);
-            display::graphics.setForegroundColor(0);
-
-            if (Data->Season == 0) {
-                draw_string(166, 197, "SPRING 19");
-            } else {
-                draw_string(166, 197, "FALL 19");
-            }
-
-            draw_number(0, 0, Data->Year);
-            display::graphics.setForegroundColor(11);
-
-            if (Data->Season == 0) {
-                draw_string(165, 196, "SPRING 19");
-            } else {
-                draw_string(165, 196, "FALL 19");
-            }
-
-            draw_number(0, 0, Data->Year);
-
             FadeIn(2, 10, 0, 0);
         }
 


### PR DESCRIPTION
Removes code in spaceport menus that redraws the date & cash on hand values. This duplicates code in DrawSpaceport() which is called prior.