### PR TITLE
Fix LM naut selection code

### DIFF
--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -1421,7 +1421,6 @@ std::vector<Astros *> LMCrew(int pad, Equipment *module)
     if (crew.size() != capacity) {
         ERROR3("LM module should have %d crew, only found %d",
                capacity, crew.size());
-        abort();
     }
 
     return crew;

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -1386,7 +1386,17 @@ Equipment *FindLunarModule()
  */
 std::vector<Astros *> LMCrew(int pad, Equipment *module)
 {
+    int8_t cPad;
+
     assert(pad >= 0 && pad <= JOINT);
+
+    if (MA[pad][0].A != NULL) {
+        cPad = pad;
+    } else if (MA[other(pad)][0].A != NULL) {
+        cPad = other(pad);
+    } else {
+        ERROR1("LMCrew: cannot find current pad");
+    }
 
     if (module == NULL) {
         ERROR1("LMCrew: argument 'module' is null");
@@ -1400,17 +1410,18 @@ std::vector<Astros *> LMCrew(int pad, Equipment *module)
     std::vector<Astros *> crew;
     int capacity = CrewSize(*module);
 
-    if (LM[pad] > 0 && MA[pad][LM[pad]].A) {
-        crew.push_back(MA[pad][LM[pad]].A);
+    if (LM[cPad] > 0 && MA[cPad][LM[cPad]].A) {
+        crew.push_back(MA[cPad][LM[cPad]].A);
     }
 
-    if (capacity == 2 && CAP[pad] >= 0 && MA[pad][CAP[pad]].A) {
-        crew.push_back(MA[pad][CAP[pad]].A);
+    if (capacity == 2 && CAP[cPad] >= 0 && MA[cPad][CAP[cPad]].A) {
+        crew.push_back(MA[cPad][CAP[cPad]].A);
     }
 
     if (crew.size() != capacity) {
         ERROR3("LM module should have %d crew, only found %d",
                capacity, crew.size());
+        abort();
     }
 
     return crew;


### PR DESCRIPTION
Fixes an issue with the LM killer not being able to find the correct pad during joint missions. Fixes https://github.com/raceintospace/raceintospace/issues/607.