### PR TITLE
 Fix equipment search for docking module

### DIFF
--- a/src/game/mc2.cpp
+++ b/src/game/mc2.cpp
@@ -196,6 +196,12 @@ char WhichPart(char plr, int which)
 Equipment *GetEquipment(const struct MisEval &Mev)
 {
     Equipment *e = MH[Mev.pad][Mev.Class];
+
+    // Some equipment like docking module can be attached to the other pad
+    if (!e) {
+        e = MH[other(Mev.pad)][Mev.Class];
+    }
+
     assert(e == Mev.Ep);
     return e;
 }


### PR DESCRIPTION
Fixes a crash when GetEquipment cannot find the docking module because it is attached to the other pad.