### PR TITLE
Expand use of Esc key in exiting buildings

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -168,6 +168,7 @@ void Admin(char plr)
     }
 
     beg = 1;
+    bool exit = false;
 
     do {
         if (beg) {
@@ -234,9 +235,16 @@ void Admin(char plr)
             keyHelpText = "k128";
             FileAccess(0);
             key = 0;
+
+            if (QUIT || LOAD) {
+                exit = true;
+            }
+
             break;
 
+        case -1:
         case 7:
+            exit = true;
             break;
 
         default:
@@ -248,7 +256,7 @@ void Admin(char plr)
         if (Data->P[plr].AstroDelay > 0) {
             AImg[3] = 5;
         }
-    } while (!(i == 7 || (i == 6 && (QUIT || LOAD))));
+    } while (! exit);
 
     music_stop();
     helpText = "i000";

--- a/src/game/budget.cpp
+++ b/src/game/budget.cpp
@@ -412,7 +412,7 @@ void Budget(char player)
         GetMouse();
 
         if (mousebuttons > 0 || key > 0) { /* Gameplay */
-            if ((x >= 166 && y >= 29 && x <= 236 && y <= 41 && mousebuttons > 0) || key == K_ENTER) {
+            if ((x >= 166 && y >= 29 && x <= 236 && y <= 41 && mousebuttons > 0) || key == K_ENTER || key == K_ESCAPE) {
                 InBox(167, 29, 236, 41);
                 WaitForMouseUp();
 

--- a/src/game/hardef.cpp
+++ b/src/game/hardef.cpp
@@ -224,9 +224,15 @@ ShowHard(char plr)
                 }
 
                 /* MISC */
-            } else if ((x >= 244 && y >= 5 && x <= 314 && y <= 17)
-                       || key == K_ENTER) {
+            } else if ((x >= 244 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0)
+                       || key == K_ENTER || key == K_ESCAPE) {
                 InBox(244, 5, 314, 17);
+
+                if (key > 0) {
+                    delay(250);
+                    key = 0;
+                }
+
                 WaitForMouseUp();
                 OutBox(244, 5, 314, 17);
                 return;            /* Done */
@@ -1531,7 +1537,7 @@ RankMe(char plr)
         GetMouse();
 
         if ((x >= 0 && y >= 0 && x <= 319 && y <= 199 && mousebuttons > 0)
-            || key == K_ENTER) {
+            || key == K_ENTER || key == K_ESCAPE) {
             if (key > 0) {
                 delay(300);
                 key = 0;

--- a/src/game/museum.cpp
+++ b/src/game/museum.cpp
@@ -142,7 +142,8 @@ void Display_ARROW(char num, int x, int y)
 
 void Museum(char plr)
 {
-    int i, tots = 7, beg;
+    int i;
+    int tots = 7;
     char AName[7][22] = { "DIRECTOR RANKING", "SPACE HISTORY",
                           "MISSION RECORDS", "PRESTIGE SUMMARY",
                           "HARDWARE EFFICIENCY", "ASTRONAUT HISTORY",
@@ -161,7 +162,8 @@ void Museum(char plr)
     AImg[3] += plr;
     // FadeOut(2,pal,10,0,0);
     music_start(M_THEME);
-    beg = 0;
+    int beg = 0;
+    bool exit = false;
 
     do {
         if (beg == 0) {
@@ -206,23 +208,28 @@ void Museum(char plr)
             break;
 
         case 6:
-            helpText = (plr == 0) ? "i133" : "i134";
-            keyHelpText = (plr == 0) ? "k035" : "k441";
-
             if (Data->P[plr].AstroCount > 0) {
+                helpText = (plr == 0) ? "i133" : "i134";
+                keyHelpText = (plr == 0) ? "k035" : "k441";
                 ShowAstrosHist(plr);
+            } else {
+                exit = true;
             }
 
             break;
 
+        case -1:
         case 7:
+            exit = true;
+            break;
+
         default:
             break;
         }
 
         helpText = "i000";
         keyHelpText = "k000";
-    } while (i != beg);
+    } while (! exit);
 
     music_stop();
     return;

--- a/src/game/museum.cpp
+++ b/src/game/museum.cpp
@@ -302,7 +302,8 @@ void ShowPrest(char plr)
         GetMouse();
 
         // Parse Button actions, note that return is embedded in first pButton
-        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) || key == K_ENTER) {
+        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) ||
+            key == K_ENTER || key == K_ESCAPE) {
             InBox(245, 5, 314, 17);
 
             if (key > 0) {
@@ -692,7 +693,8 @@ void ShowSpHist(char plr)
         Mission_Data_Buttons(plr, &pos);
 
         // Parse Button actions, note that return is embedded in first pButton
-        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) || key == K_ENTER) {
+        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) ||
+            key == K_ENTER || key == K_ESCAPE) {
             InBox(245, 5, 314, 17);
 
             if (key > 0) {
@@ -1171,7 +1173,8 @@ void ShowAstrosHist(char plr)
         GetMouse();
 
         // Parse Button actions, note that continue button is not a macro
-        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) || key == K_ENTER) {
+        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) ||
+            key == K_ENTER || key == K_ESCAPE) {
             InBox(245, 5, 314, 17);
 
             if (key > 0) {

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -148,14 +148,18 @@ int MainMenuChoice()
  *
  * \param plr   the player index.
  * \param qty   how many menu options are available.
- * \param Name  an array of (qty) 22-character menu option labels.
+ * \param Name  an array of (qty) 22-character menu option labels
+ *              (Name[qty][22]).
  * \param Imx   an array of (qty) numeric indices specifying menu icons.
- * \return  the index of the selected menu option, [0, qty).
+ * \param mayEscape  true if the player may press 'ESC' to abort.
+ * \return  the index of the selected menu option, [0, qty),
+ *          or -1 to abort.
  * \throws runtime_error  if Filesystem cannot read the icon images.
  */
-int BChoice(char plr, char qty, char *Name, char *Imx)  // Name[][22]
+int BChoice(int plr, int qty, char *Name, char *Imx, bool mayEscape)
 {
-    int i, j, starty = 100;
+    int j;
+    int starty = 100;
     char filename[128];
     //FadeOut(2,pal,10,0,0);
     display::LegacySurface local(30, 19);
@@ -163,7 +167,7 @@ int BChoice(char plr, char qty, char *Name, char *Imx)  // Name[][22]
     starty -= (qty * 23 / 2);
 
     /* hard-coded magic numbers, yuck */
-    for (i = 0; i < qty; i++) {
+    for (int i = 0; i < qty; i++) {
         BCDraw(starty + 23 * i);
         draw_heading(60, starty + 4 + 23 * i, &Name[i * 22], 1, 0);
 
@@ -182,7 +186,11 @@ int BChoice(char plr, char qty, char *Name, char *Imx)  // Name[][22]
         av_block();
         GetMse(plr, 0);
 
-        for (i = 0; i < qty; i++) // keyboard stuff
+        if (mayEscape && key == K_ESCAPE) {
+            break;
+        }
+
+        for (int i = 0; i < qty; i++)  { // keyboard stuff
             if ((char)key == Name[i * 22]) {
 
                 InBox(23, starty + 23 * i, 54, starty + 20 + 23 * i);
@@ -191,9 +199,10 @@ int BChoice(char plr, char qty, char *Name, char *Imx)  // Name[][22]
                 j = i + 1;
                 key = 0;
             }
+        }
 
         if (mousebuttons != 0) {
-            for (i = 0; i < qty; i++) {
+            for (int i = 0; i < qty; i++) {
                 if ((x >= 23 && x <= 54 && y >= starty + 23 * i && y <= starty + 20 + 23 * i) ||
                     (x > 56 && y > starty + 23 * i && x < 296 && y < starty + 20 + 23 * i)) {
 

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -179,6 +179,7 @@ int BChoice(int plr, int qty, char *Name, char *Imx, bool mayEscape)
     }
 
     // FadeIn(2,pal,10,0,0);
+    key = 0;
     WaitForMouseUp();
     j = -1;
 

--- a/src/game/place.h
+++ b/src/game/place.h
@@ -16,8 +16,10 @@ void Draw_Mis_Stats(char plr, char index, int *where, char mode);
 void PatchMe(char plr, int x, int y, char prog, char poff);
 void BigHardMe(char plr, int x, int y, char hw, char unit, char sh);
 void AstFaces(char plr, int x, int y, char face);
-void SmHardMe(char plr, int x, int y, char prog, char planet, unsigned char coff);
-int BChoice(char plr, char qty, char *Name, char *Imx);
+void SmHardMe(char plr, int x, int y, char prog, char planet,
+              unsigned char coff);
+int BChoice(int plr, int qty, char *Name, char *Imx,
+            bool mayEscape = true);
 int MainMenuChoice();
 bool ScrubMissionQuery(char plr, int pad);
 

--- a/src/game/records.cpp
+++ b/src/game/records.cpp
@@ -217,7 +217,8 @@ void Records(char plr)
         GetMouse();
 
         // Parse Button actions, note that return is embedded in first pButton
-        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) || key == K_ENTER) {
+        if ((x >= 245 && y >= 5 && x <= 314 && y <= 17 && mousebuttons > 0) ||
+            key == K_ENTER || key == K_ESCAPE) {
             InBox(245, 5, 314, 17);
 
             if (key > 0) {


### PR DESCRIPTION
Add the ability to exit out of Spaceport menus (administrative, museum, intel) using the Esc key, as well as for several buildings accessed from those menus.