### PR TITLE
Add Esc option to Preferences menu

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -226,7 +226,7 @@ void Admin(char plr)
             music_stop();
             helpText = "i013";
             keyHelpText = "k013";
-            Prefs(1, plr);
+            IngamePreferences(plr);
             key = 0;
             break;
 

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -238,7 +238,7 @@ int game_main_impl(int argc, char *argv[])
     ex = 0;
 
     while (ex == 0) {
-
+        bool launchGame = false;
         MakeRecords();
 
         fname = locate_file("urast.json", FT_DATA);
@@ -276,40 +276,44 @@ int game_main_impl(int argc, char *argv[])
             helpText = "i013";
 
             if (MAIL == -1) {
-                Prefs(0, -1);                  // GET INITIAL PREFS FROM PLAYER
+                // GET INITIAL PREFS FROM PLAYER
+                launchGame = (NewGamePreferences() != PREFS_ABORTED);
             }
 
 #ifdef ALLOW_PBEM
             else { // MAIL GAME
-                Prefs(3, -1);
+                launchGame = (NewPBEMGamePreferences() != PREFS_ABORTED);
             }
 
 #endif // ALLOW_PBEM
 
-            plr[0] = Data->Def.Plr1;       // SET GLOBAL PLAYER VALUES
-            plr[1] = Data->Def.Plr2;
-            Data->plr[0] = Data->Def.Plr1;  // SET STRUCTURE PLAYER VALUES
-            Data->plr[1] = Data->Def.Plr2;
+            if (launchGame) {
+                plr[0] = Data->Def.Plr1;       // SET GLOBAL PLAYER VALUES
+                plr[1] = Data->Def.Plr2;
+                Data->plr[0] = Data->Def.Plr1;  // SET STRUCTURE PLAYER VALUES
+                Data->plr[1] = Data->Def.Plr2;
 
-            if (MAIL == -1) {
-                if (plr[0] == 2 || plr[0] == 3) {
-                    AI[0] = 1;
+                if (MAIL == -1) {
+                    if (plr[0] == 2 || plr[0] == 3) {
+                        AI[0] = 1;
+                    } else {
+                        AI[0] = 0;
+                    }
+
+                    if (plr[1] == 2 || plr[1] == 3) {
+                        AI[1] = 1;
+                    } else {
+                        AI[1] = 0;
+                    }
                 } else {
-                    AI[0] = 0;
+                    AI[0] = AI[1] = 0;
                 }
 
-                if (plr[1] == 2 || plr[1] == 3) {
-                    AI[1] = 1;
-                } else {
-                    AI[1] = 0;
-                }
-            } else {
-                AI[0] = AI[1] = 0;
+                InitData();                   // PICK EVENT CARDS N STUFF
+                MainLoop();                   // PLAY GAME
+                display::graphics.screen()->clear();
             }
 
-            InitData();                   // PICK EVENT CARDS N STUFF
-            MainLoop();                   // PLAY GAME
-            display::graphics.screen()->clear();
             break;
 
         case MAIN_OLD_GAME: // Play Old Game

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -729,7 +729,7 @@ void Prefs(int where, int player)
 
                 /* P1: Director Name */
                 if (where == 0 || where == 3 ||
-                    (where == 1 && player == 0)) {
+                    (where == 1 && (player == 0 || !IsHumanPlayer(0)))) {
                     EditDirectorName(0);
                 }
             } else if ((x >= 236 && y >= 34 && x <= 313 && y <= 42 && mousebuttons > 0) ||
@@ -737,7 +737,7 @@ void Prefs(int where, int player)
 
                 /* P2: Director Name */
                 if (where == 0 || where == 3 ||
-                    (where == 1 && player == 1)) {
+                    (where == 1 && (player == 1 || !IsHumanPlayer(1)))) {
                     EditDirectorName(1);
                 }
             }

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -28,6 +28,7 @@
 #include "prefs.h"
 
 #include <cctype>
+#include <string>
 
 #include "display/graphics.h"
 #include "display/surface.h"
@@ -52,11 +53,14 @@ struct DisplayContext {
 };
 
 void DrawPrefs(int where, char a1, char a2, DisplayContext &dctx);
+void EditDirectorName(int plr);
+std::string GetTextInput(int x, int y, int maxLength);
 void HModel(char mode, char tx);
 void Levels(char plr, char which, char x, DisplayContext &dctx);
 void BinT(int x, int y, char st);
 void PLevels(char side, char wh, DisplayContext &dctx);
 void CLevels(char side, char wh, DisplayContext &dctx);
+
 
 void DrawPrefs(int where, char a1, char a2, DisplayContext &dctx)
 {
@@ -175,6 +179,86 @@ void DrawPrefs(int where, char a1, char a2, DisplayContext &dctx)
     FadeIn(2, 10, 0, 0);
     return;
 }
+
+
+void EditDirectorName(int plr)
+{
+    int x = (plr == 0) ? 7 : 237;
+    int maxLength = MIN(12, sizeof(Data->P[plr].Name) - 1);
+    fill_rectangle(x, 35, x + 75, 41, 0);
+    std::string name = GetTextInput(x + 1, 40, maxLength);
+
+    if (name.length() > 0 && name.length() <= maxLength) {
+        memset(Data->P[plr].Name, 0, sizeof(Data->P[plr].Name));
+        strncpy(Data->P[plr].Name, name.c_str(), maxLength + 1);
+    }
+
+    display::graphics.setForegroundColor(1);
+    draw_string(x + 1, 40, &Data->P[plr].Name[0]);
+    av_sync();
+}
+
+
+/**
+ * Creates a text input field GUI element and returns user input.
+ *
+ * \param x  the x-coordinate for drawing the inputted text string.
+ * \param y  the y-coordinate for drawing the inputted text string.
+ * \param maxLength  the maximum number of characters the user may enter.
+ */
+std::string GetTextInput(int x, int y, int maxLength)
+{
+    std::string input;
+    input.reserve(maxLength + 1);
+    int key = 0;
+    int width = maxLength * 6 + 1;
+
+    fill_rectangle(x, y - 4, x + width, y, 0);
+    display::graphics.setForegroundColor(1);
+    grMoveTo(x, y);
+    draw_character(0x14);
+    av_sync();
+
+    do {
+        key = getch();
+
+        if (key != (key & 0xff)) {
+            key = 0x00;
+        } else if (key >= 'a' && key <= 'z') {
+            key = toupper(key);
+        }
+
+        if (key == 0x08) {  // Backspace
+            if (input.length()) {
+                input.pop_back();
+                fill_rectangle(x, y - 4, x + width, y, 0);
+                draw_string(x, y, input.c_str());
+                draw_character(0x14);
+                key = 0;
+            }
+        } else if (isupper(key) || isdigit(key) || key == ' ') {
+            if (input.length() < maxLength) {
+                input.push_back(key);
+                fill_rectangle(x, y - 4, x + width, y, 0);
+                draw_string(x, y, input.c_str());
+                draw_character(0x14);
+                key = 0;
+            }
+        }
+
+        av_sync();
+    } while (!(key == K_ENTER || key == K_ESCAPE));
+
+    fill_rectangle(x, y - 4, x + width, y, 0);
+
+    // Trim trailing whitespace
+    while (input.length() && input.back() == ' ') {
+        input.pop_back();
+    }
+
+    return (key == K_ENTER && input.length()) ? input : "";
+}
+
 
 /* Draw the Hardware Model / Roster settings button
  *
@@ -640,96 +724,22 @@ void Prefs(int where, int player)
 
                 Levels(1, Data->Def.Ast2, 0, dctx);
                 /* P2: Astro Level */
-            } else if ((x >= 6 && y >= 34 && x <= 83 && y <= 42 && (where == 3 || where == 0 || (where == 1 && player == 0)) && mousebuttons > 0) ||
-                       ((where == 3 || where == 0 || (where == 1 && player == 0)) && ksel == 0 && key == 'N')) {
-                fill_rectangle(7, 35, 82, 41, 0);
+            } else if ((x >= 6 && y >= 34 && x <= 83 && y <= 42 && mousebuttons > 0) ||
+                       (ksel == 0 && key == 'N')) {
 
-                for (int i = 0; i < 20; i++) {
-                    Data->P[0].Name[i] = 0x00;
-                }
-
-                num = 0;
-                ch = 0;
-                display::graphics.setForegroundColor(1);
-                grMoveTo(8, 40);
-                draw_character(0x14);
-                av_sync();
-
-                while (ch != K_ENTER) {
-                    ch = getch();
-
-                    if (ch != (ch & 0xff)) {
-                        ch = 0x00;
-                    }
-
-                    if (ch >= 'a' && ch <= 'z') {
-                        ch -= 0x20;
-                    }
-
-                    if (ch == 0x08 && num > 0) {
-                        Data->P[0].Name[--num] = 0x00;
-                    } else if (num < 12 && (isupper(ch) || isdigit(ch) || ch == 0x20)) {
-                        Data->P[0].Name[num++] = ch;
-                    }
-
-                    fill_rectangle(7, 35, 82, 41, 0);
-                    display::graphics.setForegroundColor(1);
-                    draw_string(8, 40, &Data->P[0].Name[0]);
-                    draw_character(0x14);
-                    av_sync();
-                }
-
-                Data->P[0].Name[num] = 0x00;
-                fill_rectangle(7, 35, 82, 41, 0);
-                display::graphics.setForegroundColor(1);
-                draw_string(8, 40, &Data->P[0].Name[0]);
-                av_sync();
                 /* P1: Director Name */
-            } else if ((x >= 236 && y >= 34 && x <= 313 && y <= 42 && (where == 3 || where == 0 || (where == 1 && player == 1)) && mousebuttons > 0) ||
-                       ((where == 3 || where == 0 || (where == 1 && player == 1)) && ksel == 1 && key == 'N')) {
-                fill_rectangle(237, 35, 312, 41, 0);
-
-                for (int i = 0; i < 20; i++) {
-                    Data->P[1].Name[i] = 0x00;
+                if (where == 0 || where == 3 ||
+                    (where == 1 && player == 0)) {
+                    EditDirectorName(0);
                 }
+            } else if ((x >= 236 && y >= 34 && x <= 313 && y <= 42 && mousebuttons > 0) ||
+                       (ksel == 1 && key == 'N')) {
 
-                num = 0;
-                ch = 0;
-                display::graphics.setForegroundColor(1);
-                grMoveTo(238, 40);
-                draw_character(0x14);
-                av_sync();
-
-                while (ch != K_ENTER) {
-                    ch = getch();
-
-                    if (ch != (ch & 0xff)) {
-                        ch = 0x00;
-                    }
-
-                    if (ch >= 'a' && ch <= 'z') {
-                        ch -= 0x20;
-                    }
-
-                    if (ch == 0x08 && num > 0) {
-                        Data->P[1].Name[--num] = 0x00;
-                    } else if (num < 12 && (isupper(ch) || isdigit(ch) || ch == 0x20)) {
-                        Data->P[1].Name[num++] = ch;
-                    }
-
-                    fill_rectangle(237, 35, 312, 41, 0);
-                    display::graphics.setForegroundColor(1);
-                    draw_string(238, 40, &Data->P[1].Name[0]);
-                    draw_character(0x14);
-                    av_sync();
-                }
-
-                Data->P[1].Name[num] = 0x00;
-                fill_rectangle(237, 35, 312, 41, 0);
-                display::graphics.setForegroundColor(1);
-                draw_string(238, 40, &Data->P[1].Name[0]);
-                av_sync();
                 /* P2: Director Name */
+                if (where == 0 || where == 3 ||
+                    (where == 1 && player == 1)) {
+                    EditDirectorName(1);
+                }
             }
         }
     }

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -48,6 +48,13 @@
 #include "filesystem.h"
 
 
+enum PreferencesMode {
+    PREFS_INGAME = 1,
+    PREFS_NEWGAME = 0,
+    PREFS_NEWPBEM = 3
+};
+
+
 struct DisplayContext {
     boost::shared_ptr<display::PalettizedSurface> prefs_image;
 };
@@ -60,6 +67,7 @@ void Levels(char plr, char which, char x, DisplayContext &dctx);
 void BinT(int x, int y, char st);
 void PLevels(char side, char wh, DisplayContext &dctx);
 void CLevels(char side, char wh, DisplayContext &dctx);
+int Preferences(int player, int where);
 
 
 void DrawPrefs(int where, char a1, char a2, DisplayContext &dctx)
@@ -67,8 +75,6 @@ void DrawPrefs(int where, char a1, char a2, DisplayContext &dctx)
     int mode = 0;
 
     FadeOut(2, 10, 0, 0);
-    helpText = "i013";
-    keyHelpText = "K013";
 
     display::graphics.screen()->clear();
     dctx.prefs_image->exportPalette();
@@ -424,15 +430,22 @@ void CLevels(char side, char wh, DisplayContext &dctx)
  * See documentation for HModel() for more about the Hardware Model /
  * Roster settings.
  *
- * \param where  0 for pregame setup, 1 for in-game settings, 3 for mail game
+ * \param where  current game state used for determining options
+ *               (0: Pregame setup
+ *                1: In-game settings menu
+ *                3: New PBEM game)
+ * \return PREFS_ABORTED if cancelling out of menu, PREFS_SET otherwise.
  */
-void Prefs(int where, int player)
+int Preferences(int player, int where)
 {
     int num, hum1 = 0, hum2 = 0;
     char *fname;
     char ch, Name[20], ksel = 0;
     int32_t size;
     DisplayContext dctx;
+
+    helpText = "i013";
+    keyHelpText = "K013";
 
     if (where != 3) {
         // If starting a new game, set default configuration
@@ -564,8 +577,12 @@ void Prefs(int where, int player)
                     CacheCrewFile();
 
                     music_stop();
-                    return;
+                    return PREFS_SET;
                 }
+            } else if (key == K_ESCAPE) {
+                music_stop();
+                FadeOut(2, 10, 0, 0);
+                return PREFS_ABORTED;
             } else if (key == 'P' && (where == 0 || where == 3)) {
                 fill_rectangle(59, 26, 68, 31, 3);
                 fill_rectangle(290, 26, 298, 31, 3);
@@ -743,4 +760,23 @@ void Prefs(int where, int player)
             }
         }
     }
+}
+
+
+
+void IngamePreferences(int player)
+{
+    Preferences(player, PREFS_INGAME);
+}
+
+
+int NewGamePreferences()
+{
+    return Preferences(0, PREFS_NEWGAME);
+}
+
+
+int NewPBEMGamePreferences()
+{
+    return Preferences(0, PREFS_NEWPBEM);
 }

--- a/src/game/prefs.h
+++ b/src/game/prefs.h
@@ -1,6 +1,15 @@
 #ifndef PREFS_H
 #define PREFS_H
 
-void Prefs(int where, int player);
+enum {
+    PREFS_ABORTED = 0,
+    PREFS_SET
+};
+
+
+void IngamePreferences(int player);
+int NewGamePreferences();
+int NewPBEMGamePreferences();
+
 
 #endif // PREFS_H


### PR DESCRIPTION
Allow the player to exit the Preferences menu by pressing the Esc key. If done while configuring options for a new game, this will exit to the main menu and abort the start of the new game. Also refactors some code for clarity and allows players to edit AI players names in-game.