### PR TITLE
Adds settings file to handle audio preferences

### DIFF
--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -86,6 +86,7 @@ set(game_sources
   roster_group.cpp
   roster_entry.cpp
   rush.cpp
+  settings.cpp
   start.cpp
   state_utils.cpp
   utils.cpp

--- a/src/game/data.h
+++ b/src/game/data.h
@@ -138,8 +138,8 @@ struct Defl {
     int8_t Ast1, Ast2;  /**< 0=Easy, 1=Medium, 2=Hard */
     int8_t Input;       /**< 0=Mouse, 1=Keyboard, 2=Joystick */
     int8_t Anim;        /**< 0=Full, 1=Partial, 2=Results Only */
-    int8_t Music;       /**< 0=Full, 1=Partial, 2=None */
-    int8_t Sound;       /**< 0=On, 1=Off */
+    int8_t Music;       /**< 0=Full, 1=Partial, 2=None (DEPRECATED)*/
+    int8_t Sound;       /**< 0=On, 1=Off (DEPRECATED) */
 
     template<class Archive>
     void serialize(Archive &ar, uint32_t const version)

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -63,6 +63,7 @@
 #include "records.h"
 #include "review.h"
 #include "sdlhelper.h"
+#include "settings.h"
 #include "start.h"
 #include "state_utils.h"
 #include "utils.h"
@@ -148,6 +149,7 @@ LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT)
 void Rout_Debug(int line, char *file);
 void RestoreDir(void);
 int CheckIfMissionGo(char plr, char launchIdx);
+void ConfigureAudio();
 void oclose(int fil);
 void InitData(void);
 void MMainLoop(void);
@@ -158,6 +160,8 @@ void OpenEmUp(void);
 void CloseEmUp(unsigned char error, unsigned int value);
 void VerifyCrews(char plr);
 void DumpData(void *ptr, const char *file);
+
+
 
 int game_main_impl(int argc, char *argv[])
 {
@@ -228,6 +232,8 @@ int game_main_impl(int argc, char *argv[])
     DESERIALIZE_JSON_FILE(&Assets->fails, locate_file("fails.json", FT_DATA));
 
     OpenEmUp();                   // OPEN SCREEN AND SETUP GOODIES
+
+    ConfigureAudio();
 
     if (options.want_intro) {
         Introd();
@@ -820,6 +826,23 @@ restart:                              // ON A LOAD PROG JUMPS TO HERE
 
     return;
 }
+
+
+/**
+ * Initialize audio channels.
+ *
+ * Loads the audio settings from the configuration file and sets the
+ * audio channels per user preferences.
+ */
+void ConfigureAudio()
+{
+    AudioConfig audio = LoadAudioSettings();
+
+    music_set_mute(audio.master.muted || audio.music.muted);
+    MuteChannel(AV_SOUND_CHANNEL,
+                audio.master.muted || audio.soundFX.muted);
+}
+
 
 void DockingKludge(void)
 {

--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -518,9 +518,7 @@ void PlaySequence(char plr, int step, const char *InSeq, char mode)
 
             av_block();
 
-            if (Data->Def.Sound == 1) {
-                UpdateAudio();
-            }
+            UpdateAudio();
 
             if (!BABY && !fullscreenMissionPlayback) {
                 Tick(plr);

--- a/src/game/settings.cpp
+++ b/src/game/settings.cpp
@@ -1,0 +1,135 @@
+/*
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+
+#include "settings.h"
+
+#include "fs.h"
+#include "ioexception.h"
+#include "logging.h"
+#include "options.h"
+
+
+namespace {
+
+void ResetAudioSettings(AudioConfig &audio);
+
+};
+
+
+/**
+ * Reads the audio configuration file to get the current audio settings.
+ *
+ * This checks the options.want_audio configuration setting, so it
+ * should not be called until 'options' have been loaded.
+ */
+AudioConfig LoadAudioSettings()
+{
+    AudioConfig audio;
+
+    char *configFileName = locate_file("settings.json", FT_SAVE_CHECK);
+
+    if (configFileName != NULL) {
+        DESERIALIZE_JSON_FILE(&audio, configFileName);
+    } else {
+        CNOTICE3(filesys,
+                 "Could not find audio configuration file %s,"
+                 " supplying defaults",
+                 "settings.json");
+
+        ResetAudioSettings(audio);
+
+        if (!options.want_audio) {
+            audio.master.muted = true;
+            audio.music.muted = true;
+            audio.soundFX.muted = true;
+        }
+
+        try {
+            SaveAudioSettings(audio);
+        } catch (const IOException &err) {
+            CERROR3(filesys,
+                    "Could not create audio configuration file %s",
+                    "settings.json");
+        } catch (const cereal::Exception &err) {
+            CERROR3(filesys,
+                    "Could not export audio configuration data to %s",
+                    "settings.json");
+        }
+    }
+
+    free(configFileName);
+
+    if (!options.want_audio) {
+        audio.master.muted = true;
+        audio.music.muted = true;
+        audio.soundFX.muted = true;
+    }
+
+    return audio;
+}
+
+
+/**
+ * Writes a set of audio configurations to the audio settings file.
+ *
+ * \throws IOException  if unable to create audio settings file.
+ * \throws cereal::Exception  if cereal cannot write to the JSON file.
+ */
+void SaveAudioSettings(const AudioConfig &settings)
+{
+    char *configFileName = locate_file("settings.json", FT_SAVE_CHECK);
+
+    if (configFileName == NULL) {
+        FILE *file = sOpen("settings.json", "wb", FT_SAVE);
+
+        if (file == NULL) {
+            free(configFileName);
+            throw IOException("Unable to create config file "
+                              "settings.json");
+        }
+
+        fclose(file);
+
+        configFileName = locate_file("settings.json", FT_SAVE_CHECK);
+
+        if (configFileName == NULL) {
+            throw IOException("Tried to create config file "
+                              "settings.json"
+                              " and could not find afterwards.");
+        }
+    }
+
+    SERIALIZE_JSON_FILE(settings, configFileName);
+
+    // Func locate_file requires user to free memory.
+    free(configFileName);
+}
+
+
+//----------------------------------------------------------------------
+
+
+namespace {
+
+void ResetAudioSettings(AudioConfig &audio)
+{
+    audio.master.muted = audio.music.muted = audio.soundFX.muted = false;
+    audio.master.volume = audio.music.volume = audio.soundFX.volume = 100;
+}
+
+
+};  // End of anonymous namespace

--- a/src/game/settings.h
+++ b/src/game/settings.h
@@ -1,0 +1,47 @@
+#ifndef RIS_SETTINGS
+#define RIS_SETTINGS
+
+#include "serialize.h"
+
+/**
+ * Audio configuration settings used for recording and loading user
+ * preferences configurable in-game. These are distinct from "options",
+ * which represent configuration settings inaccessible from the main
+ * game.
+ *
+ * This class is intended for use with user menus and initializing
+ * audio settings, not for being consulted in-game. RIS should prefer
+ * calls to music.h in-game.
+ */
+struct AudioConfig {
+    struct Channel {
+        bool muted;
+        int volume;
+
+        template<class Archive>
+        void serialize(Archive &ar, uint32_t const version)
+        {
+            ar(CEREAL_NVP(muted));
+            ar(CEREAL_NVP(volume));
+
+            ASSERT(volume >= 0 && volume <= 100);
+        }
+    };
+
+    Channel master, music, soundFX;
+
+    template<class Archive>
+    void serialize(Archive &ar, uint32_t const version)
+    {
+        ar(CEREAL_NVP(master));
+        ar(CEREAL_NVP(music));
+        ar(CEREAL_NVP(soundFX));
+    }
+};
+
+
+AudioConfig LoadAudioSettings();
+void SaveAudioSettings(const AudioConfig &settings);
+
+
+#endif // RIS_SETTINGS


### PR DESCRIPTION
Replaces the save-specific audio options with a configuration file stored in the savegame directory. Associating audio options with a specific game instance requires players who don't play with the default settings to constantly reselect them, particularly with PBEM games. This deprecates the audio settings in the save game files and they will no longer be checked. This resolves #402.