### PR TITLE
Terminate mission replay when Esc key pushed

### DIFF
--- a/src/game/museum.cpp
+++ b/src/game/museum.cpp
@@ -723,7 +723,7 @@ void Mission_Data_Buttons(char plr, int *where)
     char index, yr, season, j, temp = 0;
 
     auto launchReview = [](int plr, int index, int *where) {
-        Draw_Mis_Stats(plr, index, where, 0);
+        Draw_Mis_Stats(plr, index, 0);
         DrawSpaceHistoryInterface(plr);
         DrawMisHist(plr, *where);
     };

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -852,7 +852,13 @@ void writePrestigeFirst(char index)   ///index==plr
 }
 
 
-void Draw_Mis_Stats(char plr, char index, int *where, char mode)
+/**
+ *
+ * \param plr   TODO
+ * \param index TODO
+ * \param mode  0 for replay, 1 for after-mission summary.
+ */
+void Draw_Mis_Stats(int plr, int index, int mode)
 {
     if (mode == 0) {
         InBox(245, 5, 314, 17);

--- a/src/game/place.h
+++ b/src/game/place.h
@@ -12,7 +12,7 @@ enum MainMenuOption {
 };
 
 int Help(const char *FName);
-void Draw_Mis_Stats(char plr, char index, int *where, char mode);
+void Draw_Mis_Stats(int plr, int index, int mode);
 void PatchMe(char plr, int x, int y, char prog, char poff);
 void BigHardMe(char plr, int x, int y, char hw, char unit, char sh);
 void AstFaces(char plr, int x, int y, char face);

--- a/src/game/review.cpp
+++ b/src/game/review.cpp
@@ -299,7 +299,7 @@ void MisRev(char plr, int pres, int mis)
     draw_small_flag(plr, 4, 4);
 
     key = 0;
-    Draw_Mis_Stats(plr, mis, 0, 1);
+    Draw_Mis_Stats(plr, mis, 1);
     key = 0;
     display::graphics.screen()->clear();
     return;


### PR DESCRIPTION
Aborts the entire mission replay (in Space History & oppenent prestige firsts) when the Esc key is pushed. Previously, only the current video segment would be skipped. Pressing any other key will still skip only the current segment. Resolves #247. Also:
- Fixes an error where the wrong variable is referenced in Replay
- Removes unused argument passed to Draw_Mis_Stats function