### PR TITLE
Display still image when training video ends

### DIFF
--- a/src/game/ast3.cpp
+++ b/src/game/ast3.cpp
@@ -27,28 +27,53 @@
 
 // This file handles Basic and Advanced Training, Hospital, and Cemetery.
 
+#include "ast3.h"
+
+#include <string>
+
 #include "display/graphics.h"
 #include "display/surface.h"
 #include "display/image.h"
 
-#include "ast3.h"
 #include "Buzz_inc.h"
-#include "options.h"
 #include "ast0.h"
 #include "draw.h"
+#include "endianness.h"
+#include "filesystem.h"
 #include "game_main.h"
+#include "gr.h"
+#include "options.h"
+#include "pace.h"
 #include "place.h"
 #include "replay.h"
 #include "sdlhelper.h"
-#include "gr.h"
-#include "pace.h"
-#include "endianness.h"
-#include "filesystem.h"
+
+namespace
+{
 
 enum {
     HOSPITAL_BLD = 0,
     CEMETERY_BLD = 1,
 };
+
+
+class VideoBlock
+{
+public:
+    VideoBlock(int plr, std::string video)
+    {
+        Replay(plr, 0, 4, 28, 149, 82, video);
+        AbzFrame(plr, 4, 28, 149, 82, video);
+    }
+
+    ~VideoBlock()
+    {
+        display::graphics.videoRect().w = 0;
+        display::graphics.videoRect().h = 0;
+    }
+};
+
+};  // end of namespace
 
 
 void DrawTrain(char plr, char lvl);
@@ -401,32 +426,29 @@ void Train(char plr, int level)
     switch (level) {
     case 1:
         strcpy(Train, (plr == 0) ? "UTCP" : "STCP");
-        Replay(plr, 0, 4, 28, 149, 82, Train);
         break;
 
     case 2:
         strcpy(Train, (plr == 0) ? "UTLM" : "STLM");
-        Replay(plr, 0, 4, 28, 149, 82, Train);
         break;
 
     case 3:
         strcpy(Train, (plr == 0) ? "UTEV" : "STEV");
-        Replay(plr, 0, 4, 28, 149, 82, Train);
         break;
 
     case 4:
         strcpy(Train, (plr == 0) ? "UTDO" : "STDO");
-        Replay(plr, 0, 4, 28, 149, 82, Train);
         break;
 
     case 5:
         strcpy(Train, (plr == 0) ? "UTDU" : "STDU");
-        Replay(plr, 0, 4, 28, 149, 82, Train);
         break;
 
     default:
         break;
     }
+
+    VideoBlock video(plr, Train);
 
     WaitForMouseUp();
 

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -941,7 +941,7 @@ void Draw_Mis_Stats(int plr, int index, int mode)
     draw_string(225, 41, "MISSION REPLAY");
     InBox(214, 55, 310, 116);
 
-    AbzFrame(plr, index, 215, 56, 94, 60, "OOOO", mode);
+    AbzFrame(plr, 215, 56, 94, 60, index);
 
     IOBox(214, 134, 310, 148);
     display::graphics.setForegroundColor(9);
@@ -1136,7 +1136,7 @@ void Draw_Mis_Stats(int plr, int index, int mode)
                     Replay(plr, index, 215, 56, 94, 60, "OOOO");
                 }
 
-                AbzFrame(plr, index, 215, 56, 94, 60, "OOOO", mode);
+                AbzFrame(plr, 215, 56, 94, 60, index);
             }
 
             OutBox(216, 136, 308, 146);

--- a/src/game/replay.h
+++ b/src/game/replay.h
@@ -4,8 +4,10 @@
 #include <string>
 
 void DispBaby(int x, int y, int loc, char neww);
-void AbzFrame(char plr, int num, int dx, int dy, int width, int height,
-              const char *Type, char mode);
+void AbzFrame(int plr, int dx, int dy, int width, int height,
+              int mission);
+void AbzFrame(int plr, int dx, int dy, int width, int height,
+              std::string sequence);
 void Replay(char plr, int num, int dx, int dy, int width, int height,
             std::string Type);
 


### PR DESCRIPTION
After the training video in Basic or Advanced training ends, a still image of the video's first frame will be displayed rather than a blank grey block. Resolves #336.