### PR TITLE
Fix error in saving mission replay data

### DIFF
--- a/src/game/data.h
+++ b/src/game/data.h
@@ -1224,6 +1224,8 @@ typedef struct ReplayItem {
     }
 } REPLAY;
 
+CEREAL_CLASS_VERSION(ReplayItem, 2);
+
 enum Opponent_Status {Ahead, Equal, Behind};
 
 struct OLDNEWS {


### PR DESCRIPTION
Updates the version number used for saving ReplayItem objects. It defaulted to 0, which meant nothing was written out.