### PR TITLE
Fix memory leaks when checking file location

### DIFF
--- a/src/game/ast_mod.cpp
+++ b/src/game/ast_mod.cpp
@@ -108,7 +108,7 @@ void AstronautModification()
     {
         try {
 
-            if(locate_file("user.json", FT_SAVE_CHECK) != NULL) {
+            if(!locate_file("user.json", FT_SAVE_CHECK).empty()) {
                 bool useOriginal = Help("I105") > 0;
 
                 if (useOriginal) {
@@ -167,7 +167,7 @@ void AstronautModification()
             if (editFlag) {
                 bool proceed = true;
 
-                if (locate_file("user.json", FT_SAVE_CHECK)) {
+                if (!locate_file("user.json", FT_SAVE_CHECK).empty()) {
                     proceed = Help("I106") > 0;
                 }
 

--- a/src/game/downgrader.cpp
+++ b/src/game/downgrader.cpp
@@ -230,10 +230,9 @@ struct MissionType Downgrader::next()
  */
 Downgrader::Options LoadJsonDowngrades(std::string filename)
 {
-    char *path = locate_file(filename.c_str(), FT_DATA);
+    std::string path = locate_file(filename.c_str(), FT_DATA);
 
-    if (path == NULL) {
-        free(path);
+    if (path.empty()) {
         throw IOException(std::string("Unable to open path to ") +
                           filename);
     }
@@ -244,7 +243,6 @@ Downgrader::Options LoadJsonDowngrades(std::string filename)
     bool success = reader.parse(input, doc);
 
     if (! success) {
-        free(path);
         throw IOException("Unable to parse JSON input stream");
     }
 
@@ -271,6 +269,5 @@ Downgrader::Options LoadJsonDowngrades(std::string filename)
     }
 
     input.close();
-    free(path);
     return options;
 }

--- a/src/game/fs.cpp
+++ b/src/game/fs.cpp
@@ -297,10 +297,8 @@ sOpen(const char *name, const char *mode, int type)
 }
 
 /** Find and open file, if found return full path.
- * Caller is responsible for freeing the memory.
  */
-char *
-locate_file(const char *name, int type)
+std::string locate_file(const char *name, int type)
 {
     file f = try_find_file(name, "rb", type);
 
@@ -309,7 +307,13 @@ locate_file(const char *name, int type)
         fclose(f.handle);
     }
 
-    return f.path;
+    if (f.path != NULL) {
+        std::string path(f.path);
+        free(f.path);
+        return path;
+    }
+
+    return "";
 }
 
 int

--- a/src/game/fs.h
+++ b/src/game/fs.h
@@ -42,7 +42,7 @@ private:
 };
 
 extern FILE *sOpen(const char *name, const char *mode, int type);
-extern char *locate_file(const char *name, int type);
+extern std::string locate_file(const char *name, int type);
 extern FILE *open_gamedat(const char *name);
 extern FILE *open_savedat(const char *name, const char *mode);
 extern char *slurp_gamedat(const char *name);

--- a/src/game/game_main.cpp
+++ b/src/game/game_main.cpp
@@ -161,7 +161,6 @@ int game_main_impl(int argc, char *argv[])
     const char *see_readme = "look for further instructions in the README file";
 
     char ex, choice;
-    char *fname;
 
     // initialize the filesystem
     Filesystem::init(argv[0]);
@@ -238,8 +237,7 @@ int game_main_impl(int argc, char *argv[])
         bool launchGame = false;
         MakeRecords();
 
-        fname = locate_file("urast.json", FT_DATA);
-        DESERIALIZE_JSON_FILE(Data, fname);
+        DESERIALIZE_JSON_FILE(Data, locate_file("urast.json", FT_DATA));
 
         if (Data->Checksum != (sizeof(struct Players))) {
             /* XXX: too drastic */

--- a/src/game/prefs.cpp
+++ b/src/game/prefs.cpp
@@ -456,7 +456,6 @@ void CLevels(char side, char wh, DisplayContext &dctx)
 int Preferences(int player, int where)
 {
     int hum1 = 0, hum2 = 0, ksel = 0;
-    char *fname;
     char Name[20];
     DisplayContext dctx;
     AudioConfig audio = LoadAudioSettings();
@@ -545,7 +544,8 @@ int Preferences(int player, int where)
                     key = 0;
 
                     if ((where == 0 || where == 3) && (Data->Def.Input == 2 || Data->Def.Input == 3)) {
-                        fname = locate_file("hist.json", FT_DATA);
+                        std::string fname =
+                            locate_file("hist.json", FT_DATA);
 
                         ifstream os(fname);
                         cereal::JSONInputArchive ar(os);

--- a/src/game/replay.cpp
+++ b/src/game/replay.cpp
@@ -48,7 +48,6 @@ Replay(char plr, int num, int dx, int dy, int width, int height,
     int j;
     std::vector<REPLAY> Rep;
     std::vector<struct MissionSequenceKey> sSeq, fSeq;
-    char *fname;
 
     if (Type == "OOOO") {
         Rep = interimData.tempReplay.at((plr * 100) + num);
@@ -59,12 +58,8 @@ Replay(char plr, int num, int dx, int dy, int width, int height,
     mm_file vidfile;
     float fps;
 
-    // TODO: Free up memory in string returned by locate_file.
-    fname = locate_file("seq.json", FT_DATA);
-    DESERIALIZE_JSON_FILE(&sSeq, fname);
-
-    fname = locate_file("fseq.json", FT_DATA);
-    DESERIALIZE_JSON_FILE(&fSeq, fname);
+    DESERIALIZE_JSON_FILE(&sSeq, locate_file("seq.json", FT_DATA));
+    DESERIALIZE_JSON_FILE(&fSeq, locate_file("fseq.json", FT_DATA));
 
     WaitForMouseUp();
 
@@ -101,7 +96,7 @@ Replay(char plr, int num, int dx, int dy, int width, int height,
         //  update_map = 0;
         for (int i = 0; i < max && keep_going; i++) {
             char seq_name[20];
-            char fname[20];  // TODO: Don't reuse name within function!
+            char fname[20];
 
             if (Rep.at(kk).Failure) {
                 strntcpy(seq_name, fSeq.at(j).video.at(i).c_str(), sizeof(seq_name));
@@ -234,9 +229,7 @@ void AbzFrame(int plr, int dx, int dy, int width, int height,
     mm_file vidfile;
     std::vector<struct MissionSequenceKey> sSeq;
 
-    char *fname = locate_file("seq.json", FT_DATA);
-    DESERIALIZE_JSON_FILE(&sSeq, fname);
-    free(fname);
+    DESERIALIZE_JSON_FILE(&sSeq, locate_file("seq.json", FT_DATA));
 
     for (j = 0; j < sSeq.size(); j++) {
         if (sSeq.at(j).MissionIdSequence == sequence) {

--- a/src/game/roster.cpp
+++ b/src/game/roster.cpp
@@ -69,13 +69,11 @@ RosterGroup &Roster::getGroup(int player, int group_number)
 
 Roster Roster::load(const std::string filename_str)
 {
-    char *filename = locate_file(filename_str.c_str(), FT_DATA);
-    assert(filename);
+    std::string path = locate_file(filename_str.c_str(), FT_DATA);
+    assert(!path.empty());
 
-    std::ifstream roster_file(filename);
+    std::ifstream roster_file(path);
     Roster roster(roster_file);
-
-    free(filename);
 
     return roster;
 }

--- a/src/game/sdlhelper.cpp
+++ b/src/game/sdlhelper.cpp
@@ -239,18 +239,16 @@ av_setup(void)
 
 
 #ifdef SET_SDL_ICON
-    char *icon_path;
+    std::string icon_path = locate_file("moon_32x32.bmp", FT_IMAGE);
 
-    if ((icon_path = locate_file("moon_32x32.bmp", FT_IMAGE))) {
-        SDL_Surface *icon = SDL_LoadBMP(icon_path);
+    if (!icon_path.empty()) {
+        SDL_Surface *icon = SDL_LoadBMP(icon_path.c_str());
 
         if (icon != NULL) {
             SDL_WM_SetIcon(icon, NULL);
         } else {
             INFO2("setting icon failed: %s\n", SDL_GetError());
         }
-
-        free(icon_path);
     }
 
 #endif

--- a/src/game/settings.cpp
+++ b/src/game/settings.cpp
@@ -17,6 +17,8 @@
 
 #include "settings.h"
 
+#include <string>
+
 #include "fs.h"
 #include "ioexception.h"
 #include "logging.h"
@@ -41,9 +43,10 @@ AudioConfig LoadAudioSettings()
 {
     AudioConfig audio;
 
-    char *configFileName = locate_file("settings.json", FT_SAVE_CHECK);
+    std::string configFileName =
+        locate_file("settings.json", FT_SAVE_CHECK);
 
-    if (configFileName != NULL) {
+    if (!configFileName.empty()) {
         DESERIALIZE_JSON_FILE(&audio, configFileName);
     } else {
         CNOTICE3(filesys,
@@ -72,8 +75,6 @@ AudioConfig LoadAudioSettings()
         }
     }
 
-    free(configFileName);
-
     if (!options.want_audio) {
         audio.master.muted = true;
         audio.music.muted = true;
@@ -92,13 +93,13 @@ AudioConfig LoadAudioSettings()
  */
 void SaveAudioSettings(const AudioConfig &settings)
 {
-    char *configFileName = locate_file("settings.json", FT_SAVE_CHECK);
+    std::string configFileName =
+        locate_file("settings.json", FT_SAVE_CHECK);
 
-    if (configFileName == NULL) {
+    if (configFileName.empty()) {
         FILE *file = sOpen("settings.json", "wb", FT_SAVE);
 
         if (file == NULL) {
-            free(configFileName);
             throw IOException("Unable to create config file "
                               "settings.json");
         }
@@ -107,7 +108,7 @@ void SaveAudioSettings(const AudioConfig &settings)
 
         configFileName = locate_file("settings.json", FT_SAVE_CHECK);
 
-        if (configFileName == NULL) {
+        if (configFileName.empty()) {
             throw IOException("Tried to create config file "
                               "settings.json"
                               " and could not find afterwards.");
@@ -115,9 +116,6 @@ void SaveAudioSettings(const AudioConfig &settings)
     }
 
     SERIALIZE_JSON_FILE(settings, configFileName);
-
-    // Func locate_file requires user to free memory.
-    free(configFileName);
 }
 
 


### PR DESCRIPTION
Return a string instead of a char* from the locate_file function. The locate_file function relied on the caller to free the allocated memory, and this was often overlooked.