### PR TITLE
Fix for  #209

### DIFF
--- a/src/game/pace.cpp
+++ b/src/game/pace.cpp
@@ -320,7 +320,7 @@ ssize_t load_audio_file(const char *name, char **data, size_t *size)
         offset += read;
 
         if (*size <= offset) {
-            *data = (char *)xrealloc(*data, *size *= 2);
+            *data = (char *)xrealloc(*data, *size += 1024);
         }
     }
 


### PR DESCRIPTION
Modifies the buffer resizing during reading and decoding of the audio file. Previously, if the buffer became full, it was resized to twice the size, which caused buffer errors and sound artifacts. Now just increase by 1 kb progressively.