### PR TITLE
Fix underlying bug in #209 and #215

### DIFF
--- a/src/game/music_vorbis.cpp
+++ b/src/game/music_vorbis.cpp
@@ -112,6 +112,9 @@ void music_load(enum music_track track)
     // Load the file
     bytes = load_audio_file(fname, &music_files[track].buf, &music_files[track].buf_size);
 
+    // Assign the correct buffer size
+    music_files[track].buf_size = bytes;
+
     // Handle failure gracefully
     if (bytes < 0) {
         free(music_files[track].buf);


### PR DESCRIPTION
As suggested by @kkosciusz the underlying problem was that the correct buffer assignment was missing in music_load() function. This line of code fix this.