### PR TITLE
4x scaling option corrected  (#359)

### DIFF
--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -109,12 +109,12 @@ static const struct {
     },
     {
         "fullscreen", &options.want_fullscreen, "%u", 0,
-        "Set to 1 if you want (ugly) full-screen game."
+        "Set to 1 if you want to display the game at full-screen."
     },
     {
 	"4xscale",  &options.want_4xscale, "%u", 0,
 	"By default now the game is displayed at 4x scale."
-	"\n# Set to 0 if you want the game to display at the classic 2x scale."
+	"\n# Set to 0 if you want to display the game at the classic 2x scale."
     },
     {
         "debuglevel", &options.want_debug, "%u", 0,
@@ -227,9 +227,10 @@ static void
 usage(int fail)
 {
     fprintf(stderr, "usage:   raceintospace [options...]\n"
-            "options: -a -i -f -v -n\n"
+            "options: -a -i -f -s -v -n\n"
             "\t-v verbose mode\n\t\tadd this several times to get to DEBUG level\n"
-            "\t-f fullscreen mode\n\t\tugly\n"
+            "\t-f fullscreen mode\n"
+	    "\t-s 4x scale mode\n"
            );
     exit((fail) ? EXIT_FAILURE : EXIT_SUCCESS);
 }
@@ -601,6 +602,8 @@ setup_options(int argc, char *argv[])
             options.want_audio = 0;
         } else if (strcmp(str, "-f") == 0) {
             options.want_fullscreen = 1;
+	} else if (strcmp(str, "-s") == 0) {
+            options.want_4xscale = 0;
         } else if (strcmp(str, "-v") == 0) {
             options.want_debug++;
         } else {


### PR DESCRIPTION
Aditional code was needed for correct implementation if the user wants to change the screen scaling in the config file.
Testing is needed.
Additionally, minor corrections to the descriptive text for the full-screen option.