### PR TITLE
Fix for #359

### DIFF
--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -112,7 +112,7 @@ static const struct {
         "Set to 1 if you want to display the game at full-screen."
     },
     {
-	"4xscale",  &options.want_4xscale, "%u", 0,
+	"xscale",  &options.want_4xscale, "%u", 0,
 	"By default now the game is displayed at 4x scale."
 	"\n# Set to 0 if you want to display the game at the classic 2x scale."
     },


### PR DESCRIPTION
Fix the option to return to classic 2x scale (640x400) in config file. 

The problem was when read_config_file() search for the option name and found it, then search for the setting number (1 or 0). Since the name of this option was "4xscale", the number search encountered '4' first and returned an error.  
Quick fix was declare the option as "xscale" and now the config file works properly.