### PR TITLE
Minor optimization to call playvoice() function

### DIFF
--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -694,7 +694,6 @@ News(char plr)
                 PlayNewsAnim(fp);
                 PlayNewsAnim(fp);
                 PlayNewsAnim(fp);
-                PlayVoice();
                 loc++;
                 break;
 
@@ -708,7 +707,6 @@ News(char plr)
                 }
 
                 NGetVoice(plr, Data->Events[Data->Count] + 2);
-                PlayVoice();
                 Status = 0;
                 i = bline;
                 ShowEvt(plr, Data->Events[Data->Count]);
@@ -729,7 +727,6 @@ News(char plr)
                     PlayNewsAnim(fp);
                 }
 
-                PlayVoice();
                 /* the "mysterious" delay of Soviet newscaster.
                  * she is out of sync anyway... */
                 loc++;

--- a/src/game/pace.cpp
+++ b/src/game/pace.cpp
@@ -341,6 +341,7 @@ void NGetVoice(char plr, char val)
              (plr ? "sov" : "usa"), val);
     bytes = load_audio_file(fname, &soundbuf, &soundbuf_size);
     soundbuf_used = (bytes > 0) ? bytes : 0;
+    PlayVoice();
 }
 
 void PlayVoice(void)


### PR DESCRIPTION
function PlayVoice() introduced en NGetVoice, therefore no longer needed directly in News()