### PR TITLE
Fix wrong requirement penalties

### DIFF
--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -1263,7 +1263,7 @@ void Future(char plr)
 		            mission.Days = duration;
                     DrawPenaltyPopup(plr, mission);
                 } else {
-                    DrawPenaltyPopup(plr, mission);
+                    DrawPenaltyPopup(plr, missionData[misType]);
                 }
                 
             } else if ((x >= 5 && y >= 84 && x <= 16 && y <= 130 && mousebuttons > 0) ||


### PR DESCRIPTION
Fixes a bug leading to uninitialized data being used to calculate the requirement penalties in the future missions screen. Fixes #914.