### PR TITLE
Fix audio crash

### DIFF
--- a/src/game/music_vorbis.cpp
+++ b/src/game/music_vorbis.cpp
@@ -110,7 +110,7 @@ void music_load(enum music_track track)
     }
 
     // Load the file
-    bytes = load_audio_file(fname, &music_files[track].buf, &music_files[track].buf_size);
+    bytes = load_audio_file(fname, &music_files[track].buf, &music_files[track].buf_size, true);
 
     // Assign the correct buffer size
     music_files[track].buf_size = bytes;

--- a/src/game/pace.h
+++ b/src/game/pace.h
@@ -29,7 +29,7 @@ void StopAudio(char mode);
 void stop_voice(void);
 void NGetVoice(char plr, char val);
 void PlayVoice(void);
-ssize_t load_audio_file(const char *, char **data, size_t *size);
+ssize_t load_audio_file(const char *, char **data, size_t *size, bool music);
 void idle_loop(int ticks);
 void play_audio(std::string str, int mode);
 void bzdelay(int ticks);


### PR DESCRIPTION
Moves the non-music sound buffer to a fixed buffer size of 32M. This prevents a possible race condition when the buffer gets relocated, triggering a crash in the Soviet news broadcast. Fixes #920.