### PR TITLE
Revert changes to equipment modification by news events

### DIFF
--- a/src/game/news_sup.cpp
+++ b/src/game/news_sup.cpp
@@ -35,307 +35,10 @@
 #include "options.h"
 #include "pace.h"
 
-
-LOG_DEFAULT_CATEGORY(LOG_ROOT_CAT);
-
-
-/** Finds player most advanced program
-*
-* Search players safety values for its programs,
-* in descending order, to find the latest first.
-* If safety program is superior to minimum base safety, 
-* returns a index of equipment following this order:
-* 
-* 0-6 -> Probes
-* 7 – 13 -> Rockets
-* 14 -20 -> Manned
-* 21 – 27 -> Misc
-* 
-* struct Equipment has a fixed size of 7, but the real sizes are:
-* Equipment Probe[7];
-* 0 = Orbital 1 = Inter Planetary 2 = Lunar Probe
-*
-* Equipment Rocket[7];
-* 0 = One Stage 1 = Two Stage  2 = Three Stage 
-* 3 = Mega Stage 4 = Strap On Boosters Equipment  
-*
-* Equipment Manned[7];     
-* 0 = One Man Capsule  1 = Two Man Capsule  2 = Three Man Capsule 
-* 3 = Minishuttle	4 = Four Man Cap/Mod 5 = Two Man Module 6 = One Man Module
-*
-* Equipment Misc[6];        
-* 0 = Kicker Level A 1 = Kicker Level B 2 = Kicker Level C
-* 3 = EVA Suite 4 = Docking Modules 5 = Photo Recon
-*
-* \param plr: 0 US, 1 USSR
-* \param prog: program
-*/
-int FindAdvProgram(int plr, int prog) {
-    
-    int safety[25] = {0};  // Initialize in zero
-    int base[25] = {0};  // Initialize in zero
-    int index, lo, hi;
-    
-    // Assign Safety values and Base values in the arrays
-    for (int i = 0; i < 3; ++i) {
-        safety[i] = Data->P[plr].Probe[i].Safety;
-        base[i] = Data->P[plr].Probe[i].Base;
-    }
-    
-    for (int i = 0; i < 4; ++i) { // Don't consider Strap On Boosters
-        safety[i + 7] = Data->P[plr].Rocket[i].Safety;
-        base[i + 7] = Data->P[plr].Rocket[i].Base;
-    }
-
-    for (int i = 0; i < 7; ++i) {
-        safety[i + 14] = Data->P[plr].Manned[i].Safety;
-        base[i + 14] = Data->P[plr].Manned[i].Base;
-    }
-    
-    for (int i = 0; i < 4; ++i) {  // Don't consider Docking Module and Photo Recon
-        safety[i + 21] = Data->P[plr].Misc[i].Safety;
-        base[i + 21] = Data->P[plr].Misc[i].Base;
-    }
-   
-    // Remove Kicker C (USSR tech only)
-    safety[23] = 0;
-   
-    lo = 0, hi = 24;
-    switch (prog) {
-        case 1: lo = 0;  hi = 2;  break;  // PROBE programs
-        case 2: lo = 7;  hi = 11; break;  // ROCKET programs
-        case 3: lo = 14; hi = 18; break;  // MANNED programs
-        case 4: lo = 18; hi = 20; break;  // LEM programs
-        case 5: lo = 21; hi = 24; break;  // MISC programs
-        // Default lo=0, hi=24 covers all programs
-    }
-    
-    index = lo;
-    // Found most advanced program, not most researched
-    for (int i = hi; i >= lo; i--) {
-        if (safety[i] > base[i]) {
-            index = i;
-            DEBUG3("Found adv. program! index %d, safety %d", index, safety[index]);  
-            break;
-        }
-    }
-    
-    return index;
-}
-
-
-/** Assigns the correct equipment to a copy
-*
-* With the index, returns the correct struct equipment. 
-*
-* \param plr: 0 US, 1 USSR
-* \param index
-*/
-Equipment* AssignCorrectEquip(int plr, int index) {
-    
-    Equipment* equipment = nullptr;
-    
-    // Assign the correct equipment
-    if (index >= 0 && index <= 2) {
-      equipment = &Data->P[plr].Probe[index];
-    } else if (index >= 7 && index <= 11) {
-      equipment = &Data->P[plr].Rocket[index - 7];
-    } else if (index >= 14 && index <= 18) {
-      equipment = &Data->P[plr].Manned[index - 14];
-    } else if (index >= 21 && index <= 24) {
-      equipment = &Data->P[plr].Misc[index - 21];
-    }
-    
-    return equipment;
-}
-
-
-/** Steal technology from rival player
-*
-* If intelligence steals tech, find most adv. rival program and copy safety value
-* If intelligence is deceived, player program safety is reduced 
-* the amount of research achieved by rival 
-* (if rival has not researched, then safety is returned to base value) 
-*
-* \param player 0:us 1:ussr
-* \param prog: program
-* \param type 1:positive -1:negative search
-*/
-int StealMod(int plr, int prog, int type)
-{
-    DEBUG4("StealMod, plr %d, prog %d, type %d", plr, prog, type);
-    int index, oldSafety;
-    
-    if (type == 1) {
-    	// Find rival advanced program
-    	index = FindAdvProgram(other(plr), prog);
-    } else {
-    	// Find player advanced program
-    	index = FindAdvProgram(plr, prog);
-    }
-    
-    Equipment* player = AssignCorrectEquip(plr,index);
-    Equipment* rival = AssignCorrectEquip(other(plr), index);
-
-    oldSafety = player->Safety;
-        
-    // Intelligence steals info
-    if (type == 1) {
-        DEBUG3("Intelligence steals info: program %s, safety %d", rival->Name, rival->Safety);
-    	
-    	if (rival->Safety > player->MaxSafety) { // Player cheats
-    	  DEBUG3("rival cheat safety %d exceeds valid safety, assigning max safety %d as steal", rival->Safety, player->MaxSafety);
-    	  player->Safety = player->MaxSafety;
-    	  
-        } else if (rival->Safety > player->Safety) {
-    	    player->Safety = rival->Safety;
-    	}
-    }
-    
-    // Intelligence is deceived
-    if (type == -1) {
-        DEBUG1("Intelligence has been deceived");
-    	if (rival->Safety > player->Base) {
-    	    player->Safety -= (rival->Safety - player->Base);
-            if (player->Safety < player->Base) {
-                player->Safety = player->Base;
-            }
-    	} else {
-    	    player->Safety = player->Base;
-    	}
-    }
-
-    strcpy(Name, player->Name);
-    return (player->Safety - oldSafety) * type;
-}
-
-
-/** Modifies the Safety Factor
-* \param prog: program
-* \param 'type' 1:positive -1:negative modification
-* \param 'per' : value of modification to Safety
-*/
-int SafetyMod(int plr, int prog, int type, int per)
-{
-    DEBUG5("SafetyMod, plr %d, prog %d, type %d, per %d", plr, prog, type, per);
-    int index = FindAdvProgram(plr, prog);
-    Equipment* equipment = AssignCorrectEquip(plr,index);
-    
-    strcpy(Name, equipment->Name);
-    equipment->Safety += per * type;
-    
-    if (equipment->Safety > equipment->MaxSafety){
-      DEBUG3("increase safety %d exceeds max safety %d, assigning max", equipment->Safety, equipment->MaxSafety);
-      equipment->Safety = equipment->MaxSafety;
-    }
-    
-    if (equipment->Safety < equipment->Base){
-      DEBUG3("decrease safety %d exceeds min safety %d, assigning base", equipment->Safety, equipment->Base);
-      equipment->Safety = equipment->Base;
-    }
-    
-    return equipment->Safety;
-}
-
-
-/** Most advanced program is damaged, cost to repair 
-* \param prog: program
-* \param 'dam': damage
-* \param 'cost'
-*/
-int DamMod(int plr, int prog, int dam, int cost)
-{
-    DEBUG5("DamageMod, plr %d, prog %d, dam %d, cost %d", plr, prog, dam, cost);
-    int index = FindAdvProgram(plr, prog);
-    Equipment* equipment = AssignCorrectEquip(plr,index);
-    
-    strcpy(Name, equipment->Name);
-    if (options.cheat_no_damage == 0) {
-        equipment->Damage += dam;
-        equipment->DCost += cost;
-    }
-
-    return equipment->Safety;
-}
-
-
-/** Increment R&D cost on program
- * \param 'prog'
- * \param 'type'
- * \param 'val': increase in RD Cost
+/**
+ *
+ * \param type 1:postive -1:negative search
  */
-int RDMod(int plr, int prog, int type, int val)
-{
-    DEBUG5("RDMod, plr %d, prog %d, type %d, value %d", plr, prog, type, val);
-    int index = FindAdvProgram(plr, prog);
-    Equipment* equipment = AssignCorrectEquip(plr,index);
-        
-    strcpy(Name, equipment->Name);
-    equipment->RDCost += type * val;
-
-    return equipment->Safety;
-}
- 
- 
-/** Set program Safety Save Card to 1
- *  
- * \param 'prog'
- */
-int SaveMod(int plr, int prog)
-{
-    int index = FindAdvProgram(plr, prog);
-    Equipment* equipment = AssignCorrectEquip(plr,index);
-    
-    strcpy(Name, equipment->Name);
-    equipment->SaveCard = 1;
-    
-    return equipment->Safety;
-}
-
-
-/** Transfer new nauts
- */
-void NewNauts(int plr) {
-    
-    /* The original bonus astronauts & cosmonauts were:
-    REEVES, CHAMBERLAIN, YEAGER and STIPPOV, SCHLICKBERND, FARGOV -Leon */
-    
-    // US Astronauts
-    char UsName[3][14] = { "MANKE", "POWELL", "YEAGER"};
-    int UsStatsCap[3] = {1, 2, 3};
-    int UsStatsLM[3] = {2, 0, 0};
-    int UsStatsEVA[3] = {2, 0 ,1};
-    int UsStatsDock[3] = {1, 1, 1};
-    int UsStatsEndur[3] = {3, 0, 2};
-	
-    // USSR Cosmonauts
-    char SovName[3][14] = { "ILYUSHIN", "KRAMARENKO", "DOLGOV"};
-    int SovStatsCap[3] = {3, 2, 2};
-    int SovStatsLM[3] = {0, 1, 3};
-    int SovStatsEVA[3] = {0, 2 ,0};
-    int SovStatsDock[3] = {3, 0, 0};
-    int SovStatsEndur[3] = {3, 3, 1};	
-	
-    for (int i = 0; i < 3; i++) {
-        strcpy(&Data->P[plr].Pool[Data->P[plr].AstroCount].Name[0], plr ? SovName[i]: UsName[i]);
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Cap = plr ? SovStatsCap[i] : UsStatsCap[i];
-        Data->P[plr].Pool[Data->P[plr].AstroCount].LM = plr ? SovStatsLM[i] : UsStatsLM[i];
-        Data->P[plr].Pool[Data->P[plr].AstroCount].EVA = plr ? SovStatsEVA[i] : UsStatsEVA[i];
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Docking = plr ? SovStatsDock[i] : UsStatsDock[i];
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Endurance = plr ? SovStatsEndur[i] : UsStatsEndur[i];
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Status = AST_ST_TRAIN_BASIC_1;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Face = brandom(10) + 1;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Service = 1;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Compat = brandom(10) + 1;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].CR = brandom(2) + 1;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].CL = brandom(2) + 1;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Group = 9;
-        Data->P[plr].Pool[Data->P[plr].AstroCount].Mood = 85 + 5 * brandom(4);
-        Data->P[plr].AstroCount++;
-    }
-}
-
-/*
 int Steal(int plr, int prog, int type)
 {
     int i = 0, j = 0, k = 0, save[28], lo = 0, hi = 28;
@@ -417,8 +120,12 @@ int Steal(int plr, int prog, int type)
 
     return save[j];
 }
-*/
-/*
+
+/** ???
+ *
+ * \param type 1:postive -1:negative search
+ * \param per Amount of modification in percent
+ */
 int NMod(int plr, int prog, int type, int per)
 {
     int i = 0, j = 0, save[28], lo = 0, hi = 28;
@@ -431,9 +138,9 @@ int NMod(int plr, int prog, int type, int per)
         hi = lo + 3;
     }
 
-    // drvee: this loop was going to 25, not 28
+    /* drvee: this loop was going to 25, not 28 */
     for (i = 0; i < (int)ARRAY_LENGTH(Eptr); i++) {
-        // bug Mismatch between data.h(250) and this code here
+        /** \bug Mismatch between data.h(250) and this code here */
         Eptr[i] = &Data->P[plr].Probe[i];
         save[i] = ((Eptr[i]->Safety + per * type) <= (Eptr[i]->MaxSafety) && Eptr[i]->Num >= 0) ? Eptr[i]->Safety + per * type : 0;
 
@@ -476,8 +183,8 @@ int NMod(int plr, int prog, int type, int per)
 
     return save[j];
 }
-*/
-/*
+
+
 int DamMod(int plr, int prog, int dam, int cost)
 {
     int i = 0, j = 0, lo = 0, hi = 28;
@@ -530,9 +237,8 @@ int DamMod(int plr, int prog, int dam, int cost)
 
     return save[j];
 }
-*/
 
-/*
+
 int RDMods(int plr, int prog, int type, int val)
 {
     int i = 0, j = 0, save[28], lo = 0, hi = 28;
@@ -575,8 +281,8 @@ int RDMods(int plr, int prog, int type, int val)
     Eptr[j]->RDCost += type * val;
     return save[j];
 }
-*/
-/*
+
+
 int SaveMods(char plr, char prog)
 {
     int i = 0, j = 0, save[28], lo = 0, hi = 28;
@@ -666,7 +372,48 @@ int SaveMods(char plr, char prog)
 
     return save[j];
 }
-*/
 
+
+/** Transfer new nauts
+ */
+void NewNauts(int plr) {
+    
+    /* The original bonus astronauts & cosmonauts were:
+    REEVES, CHAMBERLAIN, YEAGER and STIPPOV, SCHLICKBERND, FARGOV -Leon */
+    
+    // US Astronauts
+    char UsName[3][14] = { "MANKE", "POWELL", "YEAGER"};
+    int UsStatsCap[3] = {1, 2, 3};
+    int UsStatsLM[3] = {2, 0, 0};
+    int UsStatsEVA[3] = {2, 0 ,1};
+    int UsStatsDock[3] = {1, 1, 1};
+    int UsStatsEndur[3] = {3, 0, 2};
+	
+    // USSR Cosmonauts
+    char SovName[3][14] = { "ILYUSHIN", "KRAMARENKO", "DOLGOV"};
+    int SovStatsCap[3] = {3, 2, 2};
+    int SovStatsLM[3] = {0, 1, 3};
+    int SovStatsEVA[3] = {0, 2 ,0};
+    int SovStatsDock[3] = {3, 0, 0};
+    int SovStatsEndur[3] = {3, 3, 1};	
+	
+    for (int i = 0; i < 3; i++) {
+        strcpy(&Data->P[plr].Pool[Data->P[plr].AstroCount].Name[0], plr ? SovName[i]: UsName[i]);
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Cap = plr ? SovStatsCap[i] : UsStatsCap[i];
+        Data->P[plr].Pool[Data->P[plr].AstroCount].LM = plr ? SovStatsLM[i] : UsStatsLM[i];
+        Data->P[plr].Pool[Data->P[plr].AstroCount].EVA = plr ? SovStatsEVA[i] : UsStatsEVA[i];
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Docking = plr ? SovStatsDock[i] : UsStatsDock[i];
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Endurance = plr ? SovStatsEndur[i] : UsStatsEndur[i];
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Status = AST_ST_TRAIN_BASIC_1;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Face = brandom(10) + 1;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Service = 1;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Compat = brandom(10) + 1;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].CR = brandom(2) + 1;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].CL = brandom(2) + 1;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Group = 9;
+        Data->P[plr].Pool[Data->P[plr].AstroCount].Mood = 85 + 5 * brandom(4);
+        Data->P[plr].AstroCount++;
+    }
+}
 
 // EOF

--- a/src/game/news_sup.h
+++ b/src/game/news_sup.h
@@ -2,10 +2,10 @@
 #define NEWS_SUP_H
 
 int DamMod(int plr, int prog, int dam, int cost);
-int SafetyMod(int plr, int prog, int type, int per);
-int SaveMod(int plr, int prog);
-int StealMod(int plr, int prog, int type);
-int RDMod(int plr, int prog, int type, int val);
+int NMod(int plr, int prog, int type, int per);
+int SaveMods(char plr, char prog);
+int Steal(int plr, int prog, int type);
+int RDMods(int plr, int prog, int type, int val);
 void NewNauts(int plr);
 
 #endif // NEWS_SUP_H

--- a/src/game/news_suq.cpp
+++ b/src/game/news_suq.cpp
@@ -251,7 +251,7 @@ char REvent(char plr)
 
     case 42:
     case 43:  /* increment R&D cost by 1 on most advanced program */
-        evflag = RDMod(plr, 0, 1, 1);
+        evflag = RDMods(plr, 0, 1, 1);
 
         if (evflag == 0) {
             return 1;
@@ -263,14 +263,14 @@ char REvent(char plr)
 
     case 5:
     case 47: // Improve tech of plr prog from rival prog
-        evflag = StealMod(plr, 0, 1);
+        evflag = Steal(plr, 0, 1);
 
         if (!evflag) return 1;
         break;
  
     case 6:
     case 7: // Lower tech of plr prog from rival prog
-        evflag = StealMod(plr, 0, -1);
+        evflag = Steal(plr, 0, -1);
 
         if (!evflag) return 1;
         break;
@@ -362,25 +362,25 @@ char REvent(char plr)
     // Program Saving cards ------------------------------------
 
     case 11:  // Set Safety Card for most Advanced program
-        evflag = SaveMod(plr, 0);
+        evflag = SaveMods(plr, 0);
 
         if (!evflag) return 1;
         break;
 
     case 48:  // Set Safety Card for advanced Rocket program
-        evflag = SaveMod(plr, 2);
+        evflag = SaveMods(plr, 2);
 
         if (!evflag) return 1;
         break;
 
     case 77:  // set Safety Card for advanced Capsule Program
-        evflag = SaveMod(plr, 3);
+        evflag = SaveMods(plr, 3);
 
         if (!evflag) return 1;
         break;
 
     case 93:  // set Safety Card for advanced LEM Program
-        evflag = SaveMod(plr, 4);
+        evflag = SaveMods(plr, 4);
 
         if (!evflag) return 1;
         break;
@@ -433,7 +433,7 @@ char REvent(char plr)
     case 94:  /*  this applies for the most advanced capsule program. 
                   roll four 6-sided dice and add to current safety factor. */
         x = rollSixDie(4);
-        evflag = SafetyMod(plr, 3, 1, x);
+        evflag = NMod(plr, 3, 1, x);
 
          if (!evflag) return 1;
 
@@ -443,7 +443,7 @@ char REvent(char plr)
     case 23:  /* this applies to the most advanced rocket program.
                  roll six 6-sided dice and add to current safety factor. */
         x = rollSixDie(6);
-        evflag = SafetyMod(plr, 2, 1, x);
+        evflag = NMod(plr, 2, 1, x);
 
         if (!evflag) return 1;
 
@@ -453,7 +453,7 @@ char REvent(char plr)
     case 24:  /*  this applies for the most advanced satellite program. 
                   roll four 6-sided dice and add to current safety factor. */
         x = rollSixDie(4);
-        evflag = SafetyMod(plr, 1, 1, x);
+        evflag = NMod(plr, 1, 1, x);
 
         if (!evflag) return 1;
 
@@ -461,7 +461,7 @@ char REvent(char plr)
         break;
 
     case 26:  /* select most advanced capsule program and reduce safety by 25%  */
-        evflag = SafetyMod(plr, 3, -1, 25);
+        evflag = NMod(plr, 3, -1, 25);
 
         if (!evflag) return 1;
 
@@ -469,7 +469,7 @@ char REvent(char plr)
         break;
 
     case 27:  /* select most advanced probe program and reduce safety by 15%  */
-        evflag = SafetyMod(plr, 1, -1, 15);
+        evflag = NMod(plr, 1, -1, 15);
 
         if (!evflag) return 1;
 
@@ -477,7 +477,7 @@ char REvent(char plr)
         break;
 
     case 34:  /* 20% loss most advanced capsule program */
-        evflag = SafetyMod(plr, 3, -1, 20);
+        evflag = NMod(plr, 3, -1, 20);
 
         if (!evflag) return 1;
 
@@ -485,7 +485,7 @@ char REvent(char plr)
         break;
 
     case 79:  /* select most advanced program and reduce safety by 20%  */
-        evflag = SafetyMod(plr, 0, -1, 20);
+        evflag = NMod(plr, 0, -1, 20);
 
         if (!evflag) return 1;
 


### PR DESCRIPTION
Reverts a set of changes to the handling of news events that led to unintended modification of the game logic. Fixes #903 and fixes #908.