### PR TITLE
Pin cmake version in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Get CMake
         uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
 
       - name: List $RUNNER_WORKSPACE before vcpkg is setup
         run: find $RUNNER_WORKSPACE


### PR DESCRIPTION
libogg 1.3.5 in vcpkg ports still specifies CMake 2.86. Starting with CMake 4.0,
support CMakeFiles requiring CMake <3.5 was dropped. For now, pin CMake version
in github workflows to 3.31, which is the last release in 3.x series.