### PR TITLE
Adds pull_request testing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,7 +4,11 @@
 #
 # Source: https://raw.githubusercontent.com/lukka/CppBuildTasks-Validation/v10/.github/workflows/hosted-ninja-vcpkg_submod-autocache.yml
 name: CI
-on: [push, workflow_dispatch]
+on:
+  push: {}
+  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   job:


### PR DESCRIPTION
Moves compilation check to the pull-request stage, not after it's already pushed to the repo

I think currently there are 2 pull requests hanging because of me and my not-compiling code. This should at least give confidence (or early warning) in that regard :/