### PR TITLE
Fix MaxFail() function

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -633,7 +633,7 @@ int MaxFail()
             Mev[i].StepInfo = 1003;
         }
 
-        maxval = std::max(Mev[i].StepInfo, maxval);
+        maxval = std::max((int)Mev[i].StepInfo, maxval);
 
         if (count == 53) return 1;
     }


### PR DESCRIPTION
Should fix #1052

In the end it was my poor handling of iteration over Mev... In a sense it was confusion between pointer and reference - I wanted to "point at one element at a time", but instead took the first entry and kept overwriting it with the following ones, up until the terminating one

But at least we got a lot more logs out of this adventure :)