### PR TITLE
Fix build with CMake 4.x: set CMAKE_POLICY_VERSION_MINIMUM=3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,16 +71,39 @@ if (WINDOWS)
 	")
 	install(DIRECTORY data/audio data/gamedata data/images data/video icons DESTINATION .)
 	install(FILES COPYING README.md AUTHORS DESTINATION .)
-else (WINDOWS)
+elseif(APPLE)
+	# sdl12-compat dlopen()s SDL2 at runtime; find it at configure time so
+	# fixup_bundle can copy it into the bundle alongside libSDL-1.2.0.dylib.
+	# Prefer the versioned name (libSDL2-2.0.0.dylib) since that is the first
+	# filename sdl12-compat tries via @loader_path.
+	find_library(SDL2_LIBRARY NAMES SDL2-2.0.0 SDL2
+		PATHS /opt/homebrew/opt/sdl2/lib /usr/local/opt/sdl2/lib
+		NO_DEFAULT_PATH)
+	if(NOT SDL2_LIBRARY)
+		find_library(SDL2_LIBRARY NAMES SDL2-2.0.0 SDL2 REQUIRED)
+	endif()
+	install(TARGETS raceintospace BUNDLE DESTINATION .)
+	set(CPACK_GENERATOR DragNDrop)
+	set(CPACK_DMG_VOLUME_NAME "Race Into Space")
+	install(CODE "
+		include(BundleUtilities)
+		fixup_bundle(\"\${CMAKE_INSTALL_PREFIX}/raceintospace.app\" \"\" \"\")
+		# sdl12-compat dlopen()s SDL2 at runtime via @loader_path; it must be
+		# present alongside libSDL-1.2.0.dylib in Contents/Frameworks/.
+		file(COPY \"${SDL2_LIBRARY}\"
+			DESTINATION \"\${CMAKE_INSTALL_PREFIX}/raceintospace.app/Contents/Frameworks/\")
+		execute_process(COMMAND codesign --sign - --force --deep \"\${CMAKE_INSTALL_PREFIX}/raceintospace.app\")
+	")
+else() # Linux
 	install(PROGRAMS icons/raceintospace.desktop DESTINATION share/applications)
 	install(FILES icons/raceintospace.xpm icons/raceintospace.png DESTINATION share/pixmaps)
 	install(FILES doc/org.raceintospace.Raceintospace.metainfo.xml
 		DESTINATION share/metainfo)
-        if(NOT DEFINED CPACK_GENERATOR)
-                set(CPACK_GENERATOR TGZ)
-        endif(NOT DEFINED CPACK_GENERATOR)
+	if(NOT DEFINED CPACK_GENERATOR)
+		set(CPACK_GENERATOR TGZ)
+	endif()
 
-endif(WINDOWS)
+endif()
 
 # Output generated CPack package name to a file so we can read that in CI
 configure_file("${PROJECT_SOURCE_DIR}/cmake/CpackWritePackageNames.cmake.in"
@@ -89,11 +112,11 @@ configure_file("${PROJECT_SOURCE_DIR}/cmake/CpackWritePackageNames.cmake.in"
 set(CPACK_POST_BUILD_SCRIPTS "${PROJECT_BINARY_DIR}/cmake/CpackWritePackageNames.cmake")
 set(CPACK_SOURCE_GENERATOR TGZ)
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Race into Space Team")
-if(NOT WINDOWS)
-       if(${CPACK_GENERATOR} MATCHES TGZ)
-                INSTALL(PROGRAMS dist/linux-tgz/run.sh DESTINATION .)
-       endif(${CPACK_GENERATOR} MATCHES TGZ)
-endif(NOT WINDOWS)
+if(NOT WINDOWS AND NOT APPLE)
+	if(${CPACK_GENERATOR} MATCHES TGZ)
+		install(PROGRAMS dist/linux-tgz/run.sh DESTINATION .)
+	endif()
+endif()
 include(CPack)
 
 find_program(GIT git DOC "Git program path")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -119,7 +119,19 @@
                 "vcpkg"
             ],
             "cacheVariables": {
-                "VCPKG_OVERLAY_PORTS": "./vcpkg-ports/sdl1"
+                "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-ports/sdl1"
+            }
+        },
+        {
+            "name": "macos-vcpkg-release",
+            "displayName": "Macos vcpkg release build",
+            "inherits": [
+                "release",
+                "macos",
+                "vcpkg"
+            ],
+            "cacheVariables": {
+                "VCPKG_OVERLAY_PORTS": "${sourceDir}/vcpkg-ports/sdl1"
             }
         }
     ],
@@ -148,6 +160,11 @@
             "name": "macos-vcpkg",
             "displayName": "Macos vcpkg build",
             "configurePreset": "macos-vcpkg"
+        },
+        {
+            "name": "macos-vcpkg-release",
+            "displayName": "Macos vcpkg release build",
+            "configurePreset": "macos-vcpkg-release"
         }
     ],
     "packagePresets": [
@@ -156,6 +173,13 @@
             "configurePreset": "windows-vcpkg",
             "generators": [
                 "NSIS"
+            ]
+        },
+        {
+            "name": "macos-vcpkg",
+            "configurePreset": "macos-vcpkg-release",
+            "generators": [
+                "DragNDrop"
             ]
         }
     ]


### PR DESCRIPTION
CMake 4.0 removed compatibility with `cmake_minimum_required` versions below 3.5. vcpkg ports (e.g. libogg) use old `cmake_minimum_required` values, causing the build to fail with:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

Setting `CMAKE_POLICY_VERSION_MINIMUM=3.5` in the environment of the hidden `vcpkg` preset passes the workaround through to all child cmake processes vcpkg spawns when building ports. This fix applies to all platforms (macOS, Windows, Linux) since they all inherit from the `vcpkg` hidden preset.

Fixes #988