### PR TITLE
cmakelists: Explicitly use Boost-provided BoostConfig.cmake

### DIFF
--- a/src/display/CMakeLists.txt
+++ b/src/display/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(SDL REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 find_package(PNG REQUIRED)
 add_library(
   raceintospace_display STATIC

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -97,7 +97,7 @@ find_package(Vorbis REQUIRED)
 find_package(jsoncpp REQUIRED)
 include(FixJsonCppTargets)
 find_package(cereal REQUIRED)
-find_package(Boost REQUIRED)
+find_package(Boost CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 
 # vcpkg only works with CONFIG


### PR DESCRIPTION
Remove the warning message about CMP0167 not being set by adding ``CONFIG`` to ``find_package(Boost`` (required since CMake 3.30).

Debian 11 has Boost 1.74. Debian 10 is EOL since 30 June 2024.

Context:

CMake 3.30 and above do not provide the ``FindBoost`` module so that ``find_package(Boost)`` calls, without the ``CONFIG`` or ``NO_MODULE`` options, find the upstream ``BoostConfig.cmake`` directly.

Boost 1.70 and above provide a ``BoostConfig.cmake`` package configuration file.
``find_package(Boost CONFIG)`` finds the upstream package directly, without the find module.

CMP0167 policy was introduced in CMake version 3.30 for compatibility to let projects use the Boost-provided BoostConfig.cmake without adding the ``CONFIG`` or ``NO_MODULE`` options.