### PR TITLE
endgame: Fix typo in comparison

### DIFF
--- a/src/game/endgame.cpp
+++ b/src/game/endgame.cpp
@@ -873,7 +873,7 @@ void FakeWin(char win)
     display::graphics.setForegroundColor(11);
     draw_string(10, 60, "FIRST ON THE MOON: ");
 
-    if (&Data->P[win].Pool[manOnMoon].Sex == 0) {
+    if (Data->P[win].Pool[manOnMoon].Sex == 0) {
         display::graphics.setForegroundColor(15);
     } else {
         display::graphics.setForegroundColor(17);


### PR DESCRIPTION
Don't compare on pointer address.

Fixes: a456e12b7402d1f78bb7d97c8b2074414bc494b9 ("Changed color of name of first on Moon")

Found with SonarQube.