### PR TITLE
Fix several issues found by SonarQube

### DIFF
--- a/src/display/graphics.cpp
+++ b/src/display/graphics.cpp
@@ -16,11 +16,11 @@ namespace display
 Graphics graphics;
 
 Graphics::Graphics():
-    _screen(NULL),
-    _scaledScreen(NULL),
-    _display(NULL),
-    _video(NULL),
-    _news(NULL)
+    _screen(nullptr),
+    _scaledScreen(nullptr),
+    _display(nullptr),
+    _video(nullptr),
+    _news(nullptr)
 {
 }
 
@@ -84,7 +84,7 @@ void Graphics::create(const std::string &title, bool fullscreen)
         throw std::runtime_error(SDL_GetError());
     }
 
-    SDL_WM_SetCaption(title.c_str(), NULL);
+    SDL_WM_SetCaption(title.c_str(), nullptr);
 
 }
 
@@ -102,11 +102,11 @@ void Graphics::destroy()
 
     SDL_FreeSurface(_display);
 
-    _video = NULL;
-    _news = NULL;
-    _scaledScreen = NULL;
-    _screen = NULL;
-    _display = NULL;
+    _video = nullptr;
+    _news = nullptr;
+    _scaledScreen = nullptr;
+    _screen = nullptr;
+    _display = nullptr;
 
     SDL_Quit();
 }
@@ -129,7 +129,7 @@ void Graphics::updateScale(int scale)
 /*
 void Display::present() {
     doScale();
-    SDL_BlitSurface( _scaledScreen, NULL, _display, NULL );
+    SDL_BlitSurface( _scaledScreen, nullptr, _display, nullptr );
     SDL_UpdateRect( _display, 0, 0, 0, 0 );
 }
 

--- a/src/display/image.cpp
+++ b/src/display/image.cpp
@@ -64,14 +64,14 @@ void throw_exception_on_png_error(png_structp png_ptr, png_const_charp error_msg
 
 PNGReader::PNGReader(const void *b, size_t l) : buffer((const char *)b), length(l), cursor(0)
 {
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, throw_exception_on_png_error, NULL);
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, throw_exception_on_png_error, nullptr);
     info_ptr = png_create_info_struct(png_ptr);
     png_set_read_fn(png_ptr, this, read_png_from_memory);
 }
 
 PNGReader::~PNGReader()
 {
-    png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+    png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);
 }
 
 PalettizedSurface *PNGReader::readIntoPalettizedSurface()
@@ -85,7 +85,7 @@ PalettizedSurface *PNGReader::readIntoPalettizedSurface()
     // read the alpha values into a local
     uint8_t *trans;
     int num_trans;
-    png_color_16p trans_values = NULL;
+    png_color_16p trans_values = nullptr;
 
     if (png_get_tRNS(png_ptr, info_ptr, &trans, &num_trans, &trans_values) == 0) {
         // no transparency
@@ -136,7 +136,7 @@ PalettizedSurface *readPalettizedPNG(const void *buffer, size_t length)
 {
     PNGReader r(buffer, length);
 
-    png_read_png(r.png_ptr, r.info_ptr, PNG_TRANSFORM_PACKING | PNG_TRANSFORM_STRIP_16, NULL);
+    png_read_png(r.png_ptr, r.info_ptr, PNG_TRANSFORM_PACKING | PNG_TRANSFORM_STRIP_16, nullptr);
 
     switch (png_get_color_type(r.png_ptr, r.info_ptr)) {
     case PNG_COLOR_TYPE_PALETTE: {

--- a/src/display/legacy_surface.cpp
+++ b/src/display/legacy_surface.cpp
@@ -10,7 +10,7 @@ namespace display
 {
 
 LegacySurface::LegacySurface(unsigned int width, unsigned int height) :
-    Surface(NULL),   // see note below
+    Surface(nullptr),   // see note below
     _hasValidPalette(false)
 {
     // Ideally, this constructor would be:
@@ -32,7 +32,7 @@ LegacySurface::~LegacySurface()
 void LegacySurface::clear(char colour)
 {
     _dirty = true;
-    SDL_FillRect(_screen, NULL, colour);
+    SDL_FillRect(_screen, nullptr, colour);
 }
 
 void LegacySurface::fillRect(unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2, char color)

--- a/src/display/palette.cpp
+++ b/src/display/palette.cpp
@@ -49,9 +49,9 @@ const Color Palette::get(uint8_t index) const
 SDLPaletteWrapper::SDLPaletteWrapper(SDL_Surface *sdl_surface)
     : _sdl_surface(sdl_surface)
 {
-    assert(sdl_surface != NULL);
-    assert(sdl_surface->format != NULL);
-    assert(sdl_surface->format->palette != NULL);
+    assert(sdl_surface != nullptr);
+    assert(sdl_surface->format != nullptr);
+    assert(sdl_surface->format->palette != nullptr);
 }
 
 SDLPaletteWrapper::~SDLPaletteWrapper()

--- a/src/display/surface.cpp
+++ b/src/display/surface.cpp
@@ -17,7 +17,7 @@ Surface::Surface(SDL_Surface *surface) :
 Surface::~Surface()
 {
     SDL_FreeSurface(_screen);
-    _screen = NULL;
+    _screen = nullptr;
 }
 
 SDL_Surface *Surface::surface() const

--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -1908,7 +1908,6 @@ void write_save_file(const char* Name, SaveFileHdr header)
 int SaveGame(const std::vector<SFInfo> savegames)
 {
     int done = 0, temp;
-    FILE* fin;
     std::string title;
 
     SaveFileHdr header{};

--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -308,7 +308,7 @@ bool ReadGameSaveInfo(const std::string& fname, SFInfo& saveInfo)
     SaveFileHdr header;
     FILE* fin = sOpen(fname.c_str(), "rb", FT_SAVE);
 
-    if (fin == NULL) {
+    if (fin == nullptr) {
         LOG_NOTICE("Unable to open save file %s, skipping",
                 fname.c_str());
         return false;
@@ -1049,7 +1049,7 @@ void FileText(const char* name)
     display::graphics.setForegroundColor(1);
     FILE* fin = sOpen(name, "rb", FT_SAVE);
 
-    if (fin == NULL) {
+    if (fin == nullptr) {
         display::graphics.setForegroundColor(11);
         draw_string(70, 147, "NO HISTORY RECORDED");
         return;

--- a/src/game/aimis.cpp
+++ b/src/game/aimis.cpp
@@ -1313,7 +1313,7 @@ void NewAI(char plr, char frog)
 void AIFuture(char plr, char mis, char pad, char* prog)
 {    
     char fake_prog[2]{};
-    if (prog == NULL) {
+    if (prog == nullptr) {
         prog = fake_prog;
     }
 

--- a/src/game/aipur.cpp
+++ b/src/game/aipur.cpp
@@ -67,9 +67,6 @@ void CheckAdv(char plr);
  */
 void DrawStatistics(char Win)
 {
-    char AImg[7] = {8, 9, 10, 11, 13, 14, 0}; // TODO: switch from current pixel-data-in-json to actual images
-                                              // images are already in images/portbut and are already used by BChoice()
-                                              // json simply has images with indexes listed here, but in a row
     int starty, qty;
     helpText = "i145";
     keyHelpText = "k045";
@@ -1159,7 +1156,7 @@ int GenPur(char plr, int hardware_index, int unit_index)
 
     if (hardware_index == ROCKET_HARDWARE) {
         Equipment* e = &pData->Rocket[unit_index];  // Hardware we're modifying
-        int n1, n2, n3, n4, n5, n6, n7;  // scratch variables for base safety value init
+        int n1, n2, n3, n4, n5;  // scratch variables for base safety value init
 
         // Safety levels of existing programs
         n1 = pData->Rocket[ROCKET_HW_ONE_STAGE].Safety;

--- a/src/game/ast1.cpp
+++ b/src/game/ast1.cpp
@@ -689,9 +689,8 @@ void Recruit(const char plr, const uint8_t pool, const uint8_t candidate)
 
 void AstSel(char plr)
 {
-    int i, j, k, BarA, BarB, MaxMen, Index, now, now2, max, change, min, count,
+    int i, BarA, BarB, MaxMen, Index, now, now2, max, min, count,
          ksel = 0;
-    FILE *fin;
 
     bool femaleAstronautsAllowed =
         (options.feat_female_nauts ||

--- a/src/game/ast1.cpp
+++ b/src/game/ast1.cpp
@@ -514,7 +514,7 @@ void DrawAstSel(char plr)
  *
  * \param x       the x coord of the top-left corner of the profile space.
  * \param y       the y coord of the top-left corner of the profile space.
- * \param recruit  the astronaut/cosmonaut or NULL for an empty profile.
+ * \param recruit  the astronaut/cosmonaut or nullptr for an empty profile.
  * \param display  flags indicating which recruit skills to reveal.
  */
 void DrawRecruitProfile(int x, int y, const struct ManPool *recruit,
@@ -779,7 +779,7 @@ void AstSel(char plr)
     DispEight(now, BarB);
     DrawRecruitProfile(173, 47, &Men[now], showStats);
     DispEight2(now2, BarA, count);
-    DrawRecruitProfile(12, 47, NULL, showStats);
+    DrawRecruitProfile(12, 47, nullptr, showStats);
 
     FadeIn(2, 10, 0, 0);
     WaitForMouseUp();
@@ -1209,7 +1209,7 @@ void AstSel(char plr)
 
             DispEight2(now2, BarA, count);
             DrawRecruitProfile(
-                12, 47, (count > 0) ? &Men[sel[now2]] : NULL, showStats);
+                12, 47, (count > 0) ? &Men[sel[now2]] : nullptr, showStats);
             DispEight(now, BarB);
             DrawRecruitProfile(173, 47, &Men[now], showStats);
 

--- a/src/game/ast_mod.cpp
+++ b/src/game/ast_mod.cpp
@@ -933,7 +933,7 @@ void ExportRoster(const std::vector<struct ManPool> &usaRoster,
 
     FILE *file = sOpen("user.json", "w", FT_SAVE);
 
-    if (file == NULL) {
+    if (file == nullptr) {
         throw IOException("Unable to open file user.json for writing");
     } else {
         CINFO2(filesys, "Exporting custom rosters to user.json...");

--- a/src/game/bzanim.cpp
+++ b/src/game/bzanim.cpp
@@ -228,7 +228,6 @@ size_t ImportAnimType(FILE *fin, struct AnimType &target)
  */
 size_t ImportBlockHead(FILE *fin, struct BlockHead &target)
 {
-    int32_t position = ftell(fin);
     bool success =
         fread(&target.cType, sizeof(target.cType), 1, fin) &&
         fread(&target.fSize, sizeof(target.fSize), 1, fin);

--- a/src/game/bzanim.cpp
+++ b/src/game/bzanim.cpp
@@ -60,11 +60,11 @@ void SeekAnimation(FILE *fin, const char *name);
 BZAnimation::Ptr BZAnimation::load(
     const char *file, const char *id, int x, int y)
 {
-    if (file == NULL) {
+    if (file == nullptr) {
         throw std::invalid_argument("Parameter file may not be null.");
     }
 
-    if (id == NULL) {
+    if (id == nullptr) {
         throw std::invalid_argument("Parameter id may not be null.");
     }
 
@@ -117,7 +117,7 @@ BZAnimation::BZAnimation(struct AnimType header,
                          std::vector<uint8_t *> frames,
                          int x,
                          int y)
-    : mDisplay(NULL), mHeader(header), mFrameData(frames)
+    : mDisplay(nullptr), mHeader(header), mFrameData(frames)
 {
     if (x < 0 || x >= display::Graphics::WIDTH) {
         WARNING2("Animation param x=%d out of range.", x);

--- a/src/game/draw.cpp
+++ b/src/game/draw.cpp
@@ -91,7 +91,7 @@ void draw_heading(int x, int y, const char* txt, char mode, char te)
     } letter;
     const int letterSize = sizeof(letter.width) + sizeof(letter.img);
 
-    if (txt == NULL) {
+    if (txt == nullptr) {
         // TODO: This should log an error or throw an exception.
         return;
     }

--- a/src/game/file.cpp
+++ b/src/game/file.cpp
@@ -11,7 +11,7 @@
 #define throw_error do { \
     PHYSFS_ErrorCode code = PHYSFS_getLastErrorCode(); \
     const char *error = PHYSFS_getErrorByCode(code); \
-    if (error == NULL) \
+    if (error == nullptr) \
         error = "unknown filesystem error"; \
     throw std::runtime_error(error); \
     } while (0)
@@ -35,7 +35,7 @@ void File::close()
         success = PHYSFS_close(m_phys_handle);
 
         if (success) {
-            m_handle = NULL;
+            m_handle = nullptr;
         }
     }
 }

--- a/src/game/filesystem.cpp
+++ b/src/game/filesystem.cpp
@@ -14,7 +14,7 @@ using boost::format;
 #define throw_error do { \
     PHYSFS_ErrorCode code = PHYSFS_getLastErrorCode(); \
     const char *error = PHYSFS_getErrorByCode(code); \
-    if (error == NULL) \
+    if (error == nullptr) \
         error = "unknown filesystem error"; \
     throw std::runtime_error(error); \
     } while (0)
@@ -23,7 +23,7 @@ using boost::format;
 #define throw_error_with_detail(detail) do { \
     PHYSFS_ErrorCode code = PHYSFS_getLastErrorCode(); \
     const char *error = PHYSFS_getErrorByCode(code); \
-    if (error == NULL) \
+    if (error == nullptr) \
         error = "unknown filesystem error"; \
     std::string msg = (format("%1%: %2%") % error % detail).str(); \
     throw std::runtime_error(msg); \
@@ -61,21 +61,21 @@ void Filesystem::init(const char *argv0)
         if (basedir.substr(basedir.length() - 5, 5) == ".app/") {
             // smells like a Mac OS X application bundle
             std::string resource_path = basedir + "Contents/Resources";
-            PHYSFS_mount(resource_path.c_str(), NULL, 0);
+            PHYSFS_mount(resource_path.c_str(), nullptr, 0);
         } else {
             // er, uh... search in the base directory?
-            PHYSFS_mount(basedir.c_str(), NULL, 0);
+            PHYSFS_mount(basedir.c_str(), nullptr, 0);
         }
 
         // get a platform-specific sensible directory for the app
         const char *prefdir = PHYSFS_getPrefDir("raceintospace.org", "Race Into Space");
 
-        if (prefdir == NULL) {
+        if (prefdir == nullptr) {
             throw_error_with_detail(prefdir);
         }
 
         // use this for reading, *before* the expected game data directory, thereby allowing overlays
-        success = PHYSFS_mount(prefdir, NULL, 0);
+        success = PHYSFS_mount(prefdir, nullptr, 0);
 
         if (!success) {
             throw_error_with_detail(prefdir);
@@ -96,7 +96,7 @@ void Filesystem::addPath(const char *s)
         throw_error;
     }
 
-    int success = PHYSFS_mount(s, NULL, 0);
+    int success = PHYSFS_mount(s, nullptr, 0);
 
     if (!success) {
         throw_error_with_detail(s);

--- a/src/game/fireworks.h
+++ b/src/game/fireworks.h
@@ -41,12 +41,12 @@ private:
         int life;
     };
 
-    const unsigned int mParticles;
-    const int mPlayer;
-    int mBombAge;
     int mMaxBombLife;
     int mMaxInitSpeed;
     int mMinInitSpeed;
+    const unsigned int mParticles;
+    int mBombAge;
+    const int mPlayer;
     Burst *mBomb;
     display::LegacySurface *mBackground;
 

--- a/src/game/fs.cpp
+++ b/src/game/fs.cpp
@@ -85,7 +85,7 @@ fix_pathsep(char *name)
 static FILE *
 try_fopen(const char *fname, const char *mode)
 {
-    FILE *fp = NULL;
+    FILE *fp = nullptr;
     assert(fname);
     assert(mode);
     TRACE3("trying to open `%s' (mode %s)", fname, mode);
@@ -106,10 +106,10 @@ try_fopen(const char *fname, const char *mode)
 static file
 s_open_helper(const char *base, const char *name, const char *mode, ...)
 {
-    FILE *fh = NULL;
-    file f = {NULL, NULL};
+    FILE *fh = nullptr;
+    file f = {nullptr, nullptr};
     int serrno;
-    char *p = NULL;
+    char *p = nullptr;
     char *cooked = (char *)xmalloc(1024);
     size_t len = 1024, len2 = 0;
     size_t len_base = strlen(base), len_name = strlen(name);
@@ -122,7 +122,7 @@ s_open_helper(const char *base, const char *name, const char *mode, ...)
     va_start(ap, mode);
 
     for (p = va_arg(ap, char *); p; p = va_arg(ap, char *)) {
-        char *s = NULL;
+        char *s = nullptr;
         int was_upper = 0;
         size_t len_p = strlen(p);
 
@@ -193,7 +193,7 @@ s_open_helper(const char *base, const char *name, const char *mode, ...)
 static file
 try_find_file(const char *name, const char *mode, int type)
 {
-    file f = {NULL, NULL};
+    file f = {nullptr, nullptr};
     char *gd = options.dir_gamedata;
     char *sd = options.dir_savegame;
     char *where = "";
@@ -222,7 +222,7 @@ try_find_file(const char *name, const char *mode, int type)
     case FT_DATA:
         f = s_open_helper(gd, name, newmode,
                           "gamedata",
-                          NULL);
+                          nullptr);
         where = "game data";
         break;
 
@@ -230,7 +230,7 @@ try_find_file(const char *name, const char *mode, int type)
     case FT_SAVE_CHECK:
         f = s_open_helper(sd, name, newmode,
                           "",
-                          NULL);
+                          nullptr);
         where = "savegame";
         break;
 
@@ -240,7 +240,7 @@ try_find_file(const char *name, const char *mode, int type)
                           "audio/music",
                           "audio/news",
                           "audio/sounds",
-                          NULL);
+                          nullptr);
         where = "audio";
         break;
 
@@ -249,14 +249,14 @@ try_find_file(const char *name, const char *mode, int type)
                           "video/mission",
                           "video/news",
                           "video/training",
-                          NULL);
+                          nullptr);
         where = "video";
         break;
 
     case FT_IMAGE:
         f = s_open_helper(gd, name, newmode,
                           "images",
-                          NULL);
+                          nullptr);
         where = "image";
         break;
 
@@ -265,7 +265,7 @@ try_find_file(const char *name, const char *mode, int type)
                           "audio/midi",
                           "midi",
                           "audio/music",
-                          NULL);
+                          nullptr);
         where = "midi";
         break;
 
@@ -273,7 +273,7 @@ try_find_file(const char *name, const char *mode, int type)
         assert("Unknown FT_* specified");
     }
 
-    if (f.handle == NULL && type != FT_SAVE_CHECK) {
+    if (f.handle == nullptr && type != FT_SAVE_CHECK) {
         int serrno = errno;
         WARNING3("can't find file `%s' in %s dir(s)", name, where);
         errno = serrno;
@@ -306,7 +306,7 @@ std::string locate_file(const char *name, int type)
         fclose(f.handle);
     }
 
-    if (f.path != NULL) {
+    if (f.path != nullptr) {
         std::string path(f.path);
         free(f.path);
         return path;

--- a/src/game/future.cpp
+++ b/src/game/future.cpp
@@ -1339,7 +1339,7 @@ void Future(char plr)
     }                              // Launch pad selection loop
 
     delete vh;
-    vh = NULL;
+    vh = nullptr;
     LOG_TRACE("<-Future()");
 }
 

--- a/src/game/legacy.cpp
+++ b/src/game/legacy.cpp
@@ -193,7 +193,7 @@ void LegacyLoad(SaveFileHdr header, FILE *fin, size_t fileLength)
 {
     LEGACY_REPLAY *load_buffer = nullptr;
     uint16_t dataSize, compSize;
-    int i, j;
+    int i;
     const int legacySize = 38866;
     struct LegacyPlayers *legacyData;
 

--- a/src/game/legacy.cpp
+++ b/src/game/legacy.cpp
@@ -191,7 +191,7 @@ void _SwapGameDat(struct LegacyPlayers *pData)
  */
 void LegacyLoad(SaveFileHdr header, FILE *fin, size_t fileLength)
 {
-    LEGACY_REPLAY *load_buffer = NULL;
+    LEGACY_REPLAY *load_buffer = nullptr;
     uint16_t dataSize, compSize;
     int i, j;
     const int legacySize = 38866;
@@ -249,7 +249,7 @@ void LegacyLoad(SaveFileHdr header, FILE *fin, size_t fileLength)
     fread(load_buffer, 1, sizeof(LEGACY_REPLAY) * MAX_REPLAY_ITEMS, fin);
 
     if (endianSwap) {
-        LEGACY_REPLAY *r = NULL;
+        LEGACY_REPLAY *r = nullptr;
         r = load_buffer;
 
         for (int j = 0; j < MAX_REPLAY_ITEMS; j++) {

--- a/src/game/log4c.cpp
+++ b/src/game/log4c.cpp
@@ -43,7 +43,7 @@
 struct LogCategory _LOGV(LOG_ROOT_CAT) = {
     0, 0, 0,
     STRINGIFY(LOG_ROOT_CAT), LP_UNINITIALIZED, 0,
-    NULL, 0
+    nullptr, 0
 };
 
 void _log_logEvent(struct LogCategory *category, struct LogEvent *ev, ...)
@@ -53,7 +53,7 @@ void _log_logEvent(struct LogCategory *category, struct LogEvent *ev, ...)
     while (1) {
         struct LogAppender *appender = cat->appender;
 
-        if (appender != NULL) {
+        if (appender != nullptr) {
             va_start(ev->ap, ev);
             appender->doAppend(appender, ev);
             va_end(ev->ap);
@@ -100,13 +100,13 @@ int _log_initCat(int priority, struct LogCategory *category)
 void log_setParent(struct LogCategory *cat, struct LogCategory *parent)
 {
 
-    assert(parent != NULL);
+    assert(parent != nullptr);
 
     // unlink from current parent
     if (cat->thresholdPriority != LP_UNINITIALIZED) {
         struct LogCategory **cpp = &parent->firstChild;
 
-        while (*cpp != cat && *cpp != NULL) {
+        while (*cpp != cat && *cpp != nullptr) {
             cpp = &(*cpp)->nextSibling;
         }
 
@@ -133,7 +133,7 @@ static void setInheritedThresholds(struct LogCategory *cat)
 {
     struct LogCategory *child = cat->firstChild;
 
-    for (; child != NULL; child = child->nextSibling) {
+    for (; child != nullptr; child = child->nextSibling) {
         if (child->isThreshInherited) {
             child->thresholdPriority = cat->thresholdPriority;
             setInheritedThresholds(child);

--- a/src/game/log_default.cpp
+++ b/src/game/log_default.cpp
@@ -53,7 +53,7 @@ static struct DefaultLogAppender {
     struct LogAppender appender;
     FILE *file;
     int printLoc;
-} defaultLogAppender = { { doAppend }, NULL, 1 } ;
+} defaultLogAppender = { { doAppend }, nullptr, 1 } ;
 
 struct LogAppender *log_defaultLogAppender  = &defaultLogAppender.appender;
 
@@ -61,11 +61,11 @@ static void doAppend(struct LogAppender *this0, struct LogEvent *ev)
 {
 
     // TODO: define a format field in struct for timestamp, etc.
-    const char *pn = NULL;
+    const char *pn = nullptr;
     char buf[30];
     struct DefaultLogAppender *appender = (struct DefaultLogAppender *)this0;
 
-    if (appender->file == NULL) {
+    if (appender->file == nullptr) {
         appender->file = stderr;
     }
 

--- a/src/game/mc.cpp
+++ b/src/game/mc.cpp
@@ -307,7 +307,7 @@ int Launch(char plr, char mis)
         int temp = 0;
 
         for (int i = 0; Mev[i].loc != 0x7f; ++i) {
-            /* Bugfix -> We need to skip cases when Mev[i].E is NULL */
+            /* Bugfix -> We need to skip cases when Mev[i].E is nullptr */
             /* Same solution as used in mis_m.c (MisCheck):207 */
             if (!GetEquipment(Mev[i])) {
                 continue;

--- a/src/game/mis_c.cpp
+++ b/src/game/mis_c.cpp
@@ -722,7 +722,6 @@ void DoPack(char plr, FILE* ffin, int mode, char* cde, char* fName,
         while (attempt < NORM_TABLE && attempt < Mob.size()) {
             strncpy(Val2, &Mob[attempt].Code[0],
                     sizeof(Mob[attempt].Code));
-            int maxlength = MIN(strlen(Val2), sizeof(Val2));
 
             if (strncmp(Val1, Val2, strlen(Val2)) == 0) {
                 break;

--- a/src/game/mis_m.cpp
+++ b/src/game/mis_m.cpp
@@ -1321,7 +1321,7 @@ int FailEval(char plr, const XFails& fail, MisEval& step, bool noDock)
  * This is used to find the LM for steps that affect the LM but do
  * not test the LM directly, such as Photo Recon tests.
  *
- * \return the LM, or NULL if there is none for the mission.
+ * \return the LM, or nullptr if there is none for the mission.
  */
 Equipment* FindLunarModule()
 {

--- a/src/game/museum.cpp
+++ b/src/game/museum.cpp
@@ -1161,7 +1161,7 @@ void ShowAstrosHist(char plr)
             OutBox(245, 5, 314, 17);
 
             delete vhptr2;
-            vhptr2 = NULL;
+            vhptr2 = nullptr;
             key = 0;
 
             return;

--- a/src/game/music_vorbis.cpp
+++ b/src/game/music_vorbis.cpp
@@ -63,7 +63,7 @@ struct music_key {
     { M_USPORT, "usport2" },
     { M_USSRMIL, "ussrmil" },
     { M_VICTORY, "victory" },
-    { M_MAX_MUSIC, NULL },
+    { M_MAX_MUSIC, nullptr },
 };
 
 // This structure defines each track
@@ -91,7 +91,7 @@ void music_load(enum music_track track)
     ssize_t bytes;
 
     // Check to see if the track is already loaded or known broken; if so, we're already done
-    if (music_files[track].buf != NULL || music_files[track].unplayable) {
+    if (music_files[track].buf != nullptr || music_files[track].unplayable) {
         return;
     }
 

--- a/src/game/news.cpp
+++ b/src/game/news.cpp
@@ -210,7 +210,7 @@ void OpenNews(char plr, char *buf, int bud)
         FILE *messages = sOpen((Option == 0) ? "SENDR.MSG" : "SENDH.MSG", "rb", FT_DATA);
         char old[120];
 
-        if (messages != NULL) {
+        if (messages != nullptr) {
             fread(&old, sizeof(old), 1, messages);
 
             if (old[0] != 0x00) {

--- a/src/game/options.cpp
+++ b/src/game/options.cpp
@@ -64,7 +64,7 @@
 #    define getenv SDL_getenv
 #  else
 #    warn I do not know a way to read environment on this system
-#    define getenv(a) (NULL)
+#    define getenv(a) (nullptr)
 #  endif
 #endif
 
@@ -243,7 +243,7 @@ shift_argv(char **argv, int len, int shift)
 
     for (i = shift; i < len; ++i) {
         argv[i - shift] = argv[i];
-        argv[i] = NULL;
+        argv[i] = nullptr;
     }
 }
 
@@ -379,7 +379,7 @@ write_default_config(void)
 {
     int i = 0;
     int err = 0;
-    FILE *f = NULL;
+    FILE *f = nullptr;
 
     create_save_dir();
     f = open_savedat("config", "wt");
@@ -419,11 +419,11 @@ write_default_config(void)
     return err;
 }
 
-/* return the location of user's home directory, or NULL if unknown.
+/* return the location of user's home directory, or nullptr if unknown.
  * returned string is malloc-ed */
 static char *get_homedir(void)
 {
-    char *s = NULL;
+    char *s = nullptr;
 
     if ((s = getenv("HOME"))) {
         return xstrdup(s);
@@ -432,7 +432,7 @@ static char *get_homedir(void)
 #if CONFIG_WIN32
 
     if ((s = getenv("HOMEPATH"))) {
-        char *s2 = NULL;
+        char *s2 = nullptr;
         std::string path(s);
 
         if ((s2 = getenv("HOMEDRIVE")) || (s2 = getenv("HOMESHARE"))) {
@@ -447,7 +447,7 @@ static char *get_homedir(void)
     }
 
 #endif
-    return NULL;
+    return nullptr;
 }
 
 static void
@@ -541,7 +541,7 @@ void ResetToClassicOptions()
 int
 setup_options(int argc, char *argv[])
 {
-    char *str = NULL;
+    char *str = nullptr;
     int pos, i;
 
     /* first set up defaults */

--- a/src/game/place.cpp
+++ b/src/game/place.cpp
@@ -453,7 +453,7 @@ int Help(const char *FName)
     int fsize;
 
     mode = 0; /* XXX check uninitialized */
-    NTxt = NULL; /* XXX check uninitialized */
+    NTxt = nullptr; /* XXX check uninitialized */
 
     if (!FName || strncmp(&FName[1], "000", 3) == 0) {
         return 0;
@@ -494,12 +494,12 @@ int Help(const char *FName)
             i += 6;
         } else if (Help[i] == 0x2e) {  // Period
             i++;
-            assert(NTxt != NULL);
+            assert(NTxt != nullptr);
             NTxt[j++] = (char) 0xcc;
             NTxt[j++] = (Help[i] - 0x30) * 100 + (Help[i + 1] - 0x30) * 10 + (Help[i + 2] - 0x30);
             i += 5;
         } else {   // Text of Line
-            assert(NTxt != NULL);
+            assert(NTxt != nullptr);
 
             while (Help[i] != 0x0d) {
                 NTxt[j++] = Help[i++];

--- a/src/game/port.cpp
+++ b/src/game/port.cpp
@@ -759,7 +759,7 @@ void PortRestore(unsigned int Count)
     }
 
     free(pPortOutlineRestore);
-    pPortOutlineRestore = NULL;
+    pPortOutlineRestore = nullptr;
 }
 
 

--- a/src/game/sdlhelper.cpp
+++ b/src/game/sdlhelper.cpp
@@ -180,7 +180,7 @@ play(struct audio_chunk *new_chunk, int channel)
         }
     }
 
-    new_chunk->next = NULL;
+    new_chunk->next = nullptr;
     *chp->chunk_tailp = new_chunk;
     SDL_UnlockAudio();
 }
@@ -199,7 +199,7 @@ av_silence(int channel)
 
         if (Channels[channel].chunk) {
             SDL_LockAudio();
-            Channels[channel].chunk = NULL;
+            Channels[channel].chunk = nullptr;
             Channels[channel].chunk_tailp = &Channels[channel].chunk;
             Channels[channel].offset = 0;
             SDL_UnlockAudio();
@@ -242,8 +242,8 @@ av_setup(void)
     if (!icon_path.empty()) {
         SDL_Surface *icon = SDL_LoadBMP(icon_path.c_str());
 
-        if (icon != NULL) {
-            SDL_WM_SetIcon(icon, NULL);
+        if (icon != nullptr) {
+            SDL_WM_SetIcon(icon, nullptr);
         } else {
             INFO2("setting icon failed: %s\n", SDL_GetError());
         }
@@ -274,13 +274,13 @@ av_setup(void)
         for (i = 0; i < AV_NUM_CHANNELS; ++i) {
             Channels[i].volume = AV_MAX_VOLUME;
             Channels[i].mute = 0;
-            Channels[i].chunk = NULL;
+            Channels[i].chunk = nullptr;
             Channels[i].chunk_tailp = &Channels[i].chunk;
             Channels[i].offset = 0;
         }
 
         /* we don't care what we got, library will convert for us */
-        if (SDL_OpenAudio(&audio_desired, NULL) < 0) {
+        if (SDL_OpenAudio(&audio_desired, nullptr) < 0) {
             ERROR2("SDL_OpenAudio error: %s", SDL_GetError());
             NOTICE1("disabling audio");
             have_audio = 0;
@@ -289,7 +289,7 @@ av_setup(void)
         }
     }
 
-    SDL_AddTimer(30, sdl_timer_callback, NULL);
+    SDL_AddTimer(30, sdl_timer_callback, nullptr);
 }
 
 static void
@@ -511,7 +511,7 @@ SDL_Scale2x(SDL_Surface *src, SDL_Surface *dst)
                                    pf->BitsPerPixel, pf->Rmask, pf->Gmask, pf->Bmask, pf->Amask);
 
     if (!dst) {
-        return NULL;
+        return nullptr;
     }
 
     bpp = pf->BytesPerPixel;
@@ -521,7 +521,7 @@ SDL_Scale2x(SDL_Surface *src, SDL_Surface *dst)
         || bpp != dst->format->BytesPerPixel) {
         SDL_SetError("dst surface size or bpp mismatch (%d vs %d)",
                      bpp, dst->format->BytesPerPixel);
-        return NULL;
+        return nullptr;
     }
 
     if (bpp == 1) {
@@ -618,14 +618,14 @@ SDL_Scale4x(SDL_Surface *src, SDL_Surface *dst)
                                    pf->BitsPerPixel, pf->Rmask, pf->Gmask, pf->Bmask, pf->Amask);
 
     if (!dst) {
-        return NULL;
+        return nullptr;
     }
 
     bpp = pf->BytesPerPixel;
 
     if (4 * src->h != dst->h || 4 * src->w != dst->w || bpp != dst->format->BytesPerPixel) {
         SDL_SetError("dst surface size or bpp mismatch (%d vs %d)", bpp, dst->format->BytesPerPixel);
-        return NULL;
+        return nullptr;
     }
 
     if (bpp == 1) {
@@ -860,7 +860,7 @@ av_sync(void)
     
     transform_palette();
     SDL_SetColors(display::graphics.scaledScreenSurface(), pal_colors, 0, 256);
-    SDL_BlitSurface(display::graphics.scaledScreenSurface(), NULL, display::graphics.displaySurface(), NULL);
+    SDL_BlitSurface(display::graphics.scaledScreenSurface(), nullptr, display::graphics.displaySurface(), nullptr);
 
     if (display::graphics.videoRect().h && display::graphics.videoRect().w) {
         r.h = display::graphics.SCALE * display::graphics.videoRect().h;

--- a/src/game/settings.cpp
+++ b/src/game/settings.cpp
@@ -99,7 +99,7 @@ void SaveAudioSettings(const AudioConfig &settings)
     if (configFileName.empty()) {
         FILE *file = sOpen("settings.json", "wb", FT_SAVE);
 
-        if (file == NULL) {
+        if (file == nullptr) {
             throw IOException("Unable to create config file "
                               "settings.json");
         }

--- a/src/game/spot.cpp
+++ b/src/game/spot.cpp
@@ -81,7 +81,7 @@ boost::shared_ptr<display::LegacySurface> portViewBuffer;
 bool SUSPEND = true;
 bool isTrackPlaying = false;
 int16_t stepCount;     // stepCount is the number of steps
-FILE *sFin = NULL;
+FILE *sFin = nullptr;
 struct SpotHeader mainHeader;
 struct AnimationStep sPath;
 struct CelHeader sImg;
@@ -140,7 +140,7 @@ void SpotClose()
  */
 void SpotInit()
 {
-    sFin = NULL;
+    sFin = nullptr;
     stepCount = -1;
     SUSPEND = false;
     isTrackPlaying = false;
@@ -169,7 +169,7 @@ void SpotKill()
 {
     if (sFin) {
         fclose(sFin);
-        sFin = NULL;
+        sFin = nullptr;
     }
 
     sPath.iHold = 0;
@@ -398,9 +398,9 @@ void AdvanceFrame()
         display::graphics.legacyScreen(), sPath.xPut, sPath.yPut);
 
     delete frameBackground;
-    frameBackground = NULL;
+    frameBackground = nullptr;
     delete celImage;
-    celImage = NULL;
+    celImage = nullptr;
 }
 
 

--- a/src/game/utils.cpp
+++ b/src/game/utils.cpp
@@ -31,7 +31,7 @@ double get_time()
 #else
     struct timeval tv;
 
-    gettimeofday(&tv, NULL);
+    gettimeofday(&tv, nullptr);
     return tv.tv_sec + tv.tv_usec / 1e6;
 #endif
 }

--- a/src/game/vab.cpp
+++ b/src/game/vab.cpp
@@ -460,7 +460,7 @@ int FillVab(char plr, char f, char mode)
             MissionHardware(plr, static_cast<MissionHardwareType>(i),
                             VAS[f][i].dex);
 
-        if (equip == NULL || equip->Num == PROGRAM_NOT_STARTED) {
+        if (equip == nullptr || equip->Num == PROGRAM_NOT_STARTED) {
             continue;
         }
 
@@ -498,7 +498,7 @@ int ChkDelVab(char plr, char f)
             MissionHardware(plr, static_cast<MissionHardwareType>(i),
                             VAS[f][i].dex);
 
-        if (equip != NULL && (equip->Num - equip->Spok) <= 0 &&
+        if (equip != nullptr && (equip->Num - equip->Spok) <= 0 &&
             equip->Delay > 0) {
             return 0;
         }
@@ -944,7 +944,7 @@ void DispRck(char plr, char wh, const display::LegacySurface *hw)
  * \param plr      the player index
  * \param slot     the mission payload slot
  * \param program  the equipment index (EquipProbeIndex, etc.)
- * \return   the equipment entry, or NULL if no match (program < 0).
+ * \return   the equipment entry, or nullptr if no match (program < 0).
  */
 Equipment *MissionHardware(char plr, enum MissionHardwareType slot,
                            int program)
@@ -952,7 +952,7 @@ Equipment *MissionHardware(char plr, enum MissionHardwareType slot,
     assert(0 <= plr && plr < NUM_PLAYERS);
 
     if (program < 0) {
-        return NULL;
+        return nullptr;
     }
 
     switch (slot) {

--- a/src/game/vehicle.cpp
+++ b/src/game/vehicle.cpp
@@ -34,7 +34,7 @@
  * \param hasBoosters
  */
 Vehicle::Vehicle(int player, int rocketIndex, bool hasBoosters)
-    : mPrimary(NULL), mSecondary(NULL)
+    : mPrimary(nullptr), mSecondary(nullptr)
 {
     if (player < 0 || player >= NUM_PLAYERS) {
         std::stringstream err;
@@ -167,7 +167,7 @@ std::list<Equipment *> Vehicle::needed()
         parts.push_back(mPrimary);
     }
 
-    if (mSecondary != NULL && mSecondary->Num <= mSecondary->Spok) {
+    if (mSecondary != nullptr && mSecondary->Num <= mSecondary->Spok) {
         parts.push_back(mSecondary);
     }
 

--- a/src/utils/but2png.c
+++ b/src/utils/but2png.c
@@ -206,7 +206,7 @@ int write_image()
         return 4;
     }
 
-    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 
     if (!png_ptr) {
         return 5;
@@ -262,7 +262,7 @@ int write_image()
     }
 
     if (maximum_transparent_color >= 0) {
-        png_set_tRNS(png_ptr, info_ptr, alpha_values, maximum_transparent_color + 1, NULL);
+        png_set_tRNS(png_ptr, info_ptr, alpha_values, maximum_transparent_color + 1, nullptr);
     }
 
     // copy the offset, if any
@@ -276,7 +276,7 @@ int write_image()
 
     png_set_rows(png_ptr, info_ptr, rows);
 
-    png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
+    png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, nullptr);
 
     return 0;
 }

--- a/src/utils/data_decoder.cpp
+++ b/src/utils/data_decoder.cpp
@@ -467,7 +467,7 @@ void write_player_data(FILE *fp)
 
 //#define WRITE_UNCOMPRESSED_RAST_DAT_FILE
 #ifdef WRITE_UNCOMPRESSED_RAST_DAT_FILE
-    FILE *fout = NULL;
+    FILE *fout = nullptr;
     fout = fopen("URAST.DAT", "wb");
     fwrite(&record, bytes_uncompressed, 1, fout);
     fclose(fout);
@@ -611,9 +611,9 @@ void write_help(FILE *fp)
         strncpy(record.Code, helpHdr[i].Code, 6);
         token = strtok(buffer, "\n\r");
 
-        while (token != NULL && n < 100) {
+        while (token != nullptr && n < 100) {
             strncpy(record.description[n++], token, 40);
-            token = strtok(NULL, "\n\r");
+            token = strtok(nullptr, "\n\r");
         }
 
         RecordStart();

--- a/src/utils/mkmovie.c
+++ b/src/utils/mkmovie.c
@@ -76,11 +76,11 @@ frm_open(char *filename) {
     struct frm *frm;
     FILE *fin;
 
-    if ((fin = fopen(filename, "rb")) == NULL) {
-        return (NULL);
+    if ((fin = fopen(filename, "rb")) == nullptr) {
+        return (nullptr);
     }
 
-    if ((frm = calloc(1, sizeof *frm)) == NULL) {
+    if ((frm = calloc(1, sizeof *frm)) == nullptr) {
         fprintf(stderr, "out of memory\n");
         exit(EXIT_FAILURE);
     }
@@ -207,7 +207,7 @@ main(int argc, char **argv)
         usage();
     }
 
-    if ((frm = frm_open(filename)) == NULL) {
+    if ((frm = frm_open(filename)) == nullptr) {
         fprintf(stderr, "can't open %s\n", filename);
         exit(EXIT_FAILURE);
     }
@@ -228,7 +228,7 @@ main(int argc, char **argv)
         snprintf(outfname, sizeof(outfname), "%s/%s.%04d.ppm",
                  dirname, basename, num++);
 
-        if ((movief = fopen(outfname, "wb")) == NULL) {
+        if ((movief = fopen(outfname, "wb")) == nullptr) {
             fprintf(stderr, "can't create %s\n", outfname);
             exit(EXIT_FAILURE);
         }

--- a/src/utils/mknews.c
+++ b/src/utils/mknews.c
@@ -505,7 +505,7 @@ news_open(char *fname) {
 
     n->anim_idx = -1;
     n->frame_idx = -1;
-    n->frames = NULL;
+    n->frames = nullptr;
     return n;
 }
 
@@ -623,7 +623,7 @@ write_image(char *data, int width, int height, unsigned char *palette,
     char fname[1000];
     unsigned char r, g, b, pix;
     int i;
-    unsigned char *pp = NULL;
+    unsigned char *pp = nullptr;
     struct type {
         int is_usa;
         int is_bw;
@@ -732,7 +732,7 @@ main(int argc, char **argv)
         usage(EXIT_FAILURE);
     }
 
-    if ((news = news_open(filename)) == NULL) {
+    if ((news = news_open(filename)) == nullptr) {
         fprintf(stderr, "can't open %s\n", filename);
         exit(EXIT_FAILURE);
     }

--- a/src/utils/news2png.cpp
+++ b/src/utils/news2png.cpp
@@ -449,7 +449,7 @@ int WriteImage(const char *filename, int width, int height, Color pal[256],
     }
 
     png_ptr = png_create_write_struct(
-        PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+        PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 
     if (!png_ptr) {
         return 5;
@@ -500,7 +500,7 @@ int WriteImage(const char *filename, int width, int height, Color pal[256],
 
     png_set_rows(png_ptr, info_ptr, rows);
 
-    png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
+    png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, nullptr);
 
     return 0;
 }


### PR DESCRIPTION
* Replace NULL by nullptr
C++11 has introduced nullptr as a replacement for the NULL macro.

* Remove unused variables

* fireworks: Fix declaration order to avoid using uninitialized mMaxBombLife
``mMaxBombLife`` was being used in ``Fireworks::Fireworks`` for
``mBombAge`` before initialization, because they happen in order of
declaration, not in the order of the initializer list.
