### PR TITLE
graphics: Replace DEPRECATED by TODO for legacyScreen

### DIFF
--- a/src/display/graphics.h
+++ b/src/display/graphics.h
@@ -56,7 +56,8 @@ public:
         return _screen;
     }
 
-    DEPRECATED(LegacySurface *legacyScreen());
+    // TODO: Remove all uses of legacyScreen
+    LegacySurface *legacyScreen();
 
     SDL_Rect &videoRect()
     {


### PR DESCRIPTION
The DEPRECATED attribute fills the build log with many deprecation messages, which prevents us from seeing the actual compiler warnings.

f6c41d87bad97c540e0b977bfa22b7a036982fc4 ("Make legacy screen accesses explicit") already made this deprecation explicit in the code.

The actual work to fix it is covered by the issue #7 ("Create screen abstraction").