### PR TITLE
cmakelists: Don't restrict git describe to annotated tags for extended version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,7 @@ else()
 endif ()
 
 if (GIT)
-  execute_process(COMMAND ${GIT} describe
+  execute_process(COMMAND ${GIT} describe --tags
 		  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		  OUTPUT_VARIABLE raceintospace_BUILD OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()


### PR DESCRIPTION
Since v2.0.0rc3 is the latest annotated tag (whereas v2.0.0 is a lightweight tag), that's the extended version information that was shown to developers.

Link: https://git-scm.com/book/en/v2/Git-Basics-Tagging