### PR TITLE
cmakepresets: Add missing build preset for linux-debug

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -152,6 +152,11 @@
             "configurePreset": "linux-release"
         },
         {
+            "name": "linux-debug",
+            "displayName": "Linux debug build",
+            "configurePreset": "linux-debug"
+        },
+        {
             "name": "linux-vcpkg",
             "displayName": "Linux vcpkg build",
             "configurePreset": "linux-vcpkg"


### PR DESCRIPTION
This is needed to be able to use "cmake --preset linux-debug ; cmake --build --preset linux-debug" to get debug symbols.