### PR TITLE
Fix crash when removing last savegame and improve readability

### DIFF
--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -540,7 +540,6 @@ void FileAccess(char mode)
                 now = 0;
                 BarB = 0;
                 DrawFiles(now, BarB, savegames);
-                FileText(&savegames[now].Name[0]);
 
                 if (savegames.size() == 0) {
                     InBox(207, 48, 280, 60);
@@ -552,7 +551,9 @@ void FileAccess(char mode)
                     display::graphics.setForegroundColor(1);
                     draw_string_highlighted(226, 98, "DELETE", 0);
                 }
-
+                else {
+                    FileText(&savegames[now].Name[0]);
+                }
             }
 
             key = 0;

--- a/src/game/admin.cpp
+++ b/src/game/admin.cpp
@@ -434,7 +434,7 @@ void FileAccess(char mode)
         }
     }
 
-    if (savegames.size() > 0) {
+    if (!savegames.empty()) {
         enable |= ENABLE_DELETE;
 
         if (sc == 0 || sc == 2) {
@@ -523,7 +523,7 @@ void FileAccess(char mode)
             if (QUIT) {
                 return;
             }
-        } else if (savegames.size() > 0 && ((x >= 209 && y >= 92 && x <= 278 && y <= 100 && mousebuttons > 0)
+        } else if (!savegames.empty() && ((x >= 209 && y >= 92 && x <= 278 && y <= 100 && mousebuttons > 0)
                                             || (key == 'D'))) {
             InBox(209, 92, 278, 100);
             delay(250);
@@ -541,7 +541,7 @@ void FileAccess(char mode)
                 BarB = 0;
                 DrawFiles(now, BarB, savegames);
 
-                if (savegames.size() == 0) {
+                if (savegames.empty()) {
                     InBox(207, 48, 280, 60);
                     fill_rectangle(208, 49, 279, 59, 3);
                     display::graphics.setForegroundColor(1);
@@ -795,7 +795,7 @@ void DrawFiles(char now, char loc, const std::vector<SFInfo>& savegames)
 
     fill_rectangle(38, 49, 190, 127, 0);
 
-    if (savegames.size() > 0) {
+    if (!savegames.empty()) {
         ShBox(39, 52 + loc * 8, 189, 60 + loc * 8);
     }
 

--- a/src/game/ast2.cpp
+++ b/src/game/ast2.cpp
@@ -495,7 +495,7 @@ void Limbo(char plr)
                 key = 0;
                 OutBox(167, 95 + 21 * i, 236, 109 + 21 * i);
 
-                if (AstroList.size() > 0) {
+                if (!AstroList.empty()) {
                     Data->P[plr].Pool[AstroList.at(now2)].Assign = i + 1;
                     Data->P[plr].Pool[AstroList.at(now2)].Unassigned = 0;
                     Data->P[plr].Pool[AstroList.at(now2)].Moved = 0;
@@ -515,7 +515,7 @@ void Limbo(char plr)
 
                 DispLeft(plr, BarA, AstroList.size(), now2, AstroList.data());
 
-                if (AstroList.size() > 0) {
+                if (!AstroList.empty()) {
                     LimboText(plr, AstroList.at(now2));
                 } else {
                     fill_rectangle(10, 52, 89, 101, 7 + plr * 3);
@@ -552,7 +552,7 @@ void Limbo(char plr)
 
                 DispLeft(plr, BarA, AstroList.size(), now2, AstroList.data());
 
-                if (AstroList.size() > 0) {
+                if (!AstroList.empty()) {
                     LimboText(plr, AstroList.at(now2));
                 }
 
@@ -560,7 +560,7 @@ void Limbo(char plr)
             }
 
             // Training Transfer
-            if ((tag == OP_TRANSFER && AstroList.size() > 0) 
+            if ((tag == OP_TRANSFER && !AstroList.empty()) 
                 &&((mousebuttons > 0 
                      && x >= 244 && y >= (95 + 21 * i) 
                      && x <= 313 && y <= (109 + 21 * i)) 
@@ -628,7 +628,7 @@ void Limbo(char plr)
 
                     DispLeft(plr, BarA, AstroList.size(), now2, AstroList.data());
 
-                    if (AstroList.size() > 0) {
+                    if (!AstroList.empty()) {
                         LimboText(plr, AstroList.at(now2));
                     } else {
                         // Clear portrait display area
@@ -667,7 +667,7 @@ void Limbo(char plr)
 
                 DispLeft(plr, BarA, AstroList.size(), now2, AstroList.data());
 
-                if (AstroList.size() > 0) {
+                if (!AstroList.empty()) {
                     LimboText(plr, AstroList.at(now2));
                 }
 
@@ -712,7 +712,7 @@ void Limbo(char plr)
                 now2 = BarA = 0;
                 DispLeft(plr, BarA, AstroList.size(), now2, AstroList.data());
 
-                if (AstroList.size() > 0) {
+                if (!AstroList.empty()) {
                     LimboText(plr, AstroList.at(now2));
                 } else {
                     fill_rectangle(10, 52, 89, 101, 7 + plr * 3);


### PR DESCRIPTION
* admin: Fix crash when removing last savegame
Don't access std::vector savegames if empty.
* Replace vectors size check by `empty()` method
For readability.