### PR TITLE
Fix building utils and ensure they stay that way

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,6 +30,9 @@ jobs:
           - os: ubuntu
             preset: linux-release
             buildDir: build/release
+          - os: ubuntu
+            preset: linux-debug-utils
+            buildDir: build/debug
           - os: macos
             preset: macos-vcpkg
             buildDir: build/debug

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,6 +68,15 @@
             ]
         },
         {
+            "name": "windows-debug-utils",
+            "displayName": "Windows debug build with utils",
+            "inherits": [
+                "debug",
+                "vcpkg",
+                "windows"
+            ]
+        },
+        {
             "name": "linux",
             "displayName": "Linux build vcpkg & ninja settings",
             "condition": {
@@ -87,6 +96,14 @@
         {
             "name": "linux-debug",
             "displayName": "Linux debug build",
+            "inherits": [
+                "debug",
+                "linux"
+            ]
+        },
+        {
+            "name": "linux-debug-utils",
+            "displayName": "Linux debug build with utils",
             "inherits": [
                 "debug",
                 "linux"
@@ -147,6 +164,14 @@
             "configurePreset": "windows-debug"
         },
         {
+            "name": "windows-debug-utils",
+            "displayName": "Windows debug build with utils",
+            "configurePreset": "windows-debug-utils",
+            "targets": [
+                "all", "but2png", "data_decoder", "mkmovie", "mknews", "news2png"
+            ]
+        },
+        {
             "name": "linux-release",
             "displayName": "Linux release build",
             "configurePreset": "linux-release"
@@ -155,6 +180,14 @@
             "name": "linux-debug",
             "displayName": "Linux debug build",
             "configurePreset": "linux-debug"
+        },
+        {
+            "name": "linux-debug-utils",
+            "displayName": "Linux debug build with utils",
+            "configurePreset": "linux-debug-utils",
+            "targets": [
+                "all", "but2png", "data_decoder", "mkmovie", "mknews", "news2png"
+            ]
         },
         {
             "name": "linux-vcpkg",

--- a/src/game/gamedata.cpp
+++ b/src/game/gamedata.cpp
@@ -253,3 +253,17 @@ DECL_PUT_END
 DECL_FREAD(, SimpleHdr, 32)
 /* DECL_FWRITE(, SimpleHdr, 32) */
 
+/* SimpleHdrW */
+
+DECL_GET_START(, SimpleHdrW)
+    DECL_GET_FIELD_SCALAR(uint32_t, size, 1)
+    DECL_GET_FIELD_SCALAR(uint32_t, offset, 1)
+DECL_GET_END
+
+DECL_PUT_START(, SimpleHdrW)
+    DECL_PUT_FIELD_SCALAR(uint32_t, size, 1)
+    DECL_PUT_FIELD_SCALAR(uint32_t, offset, 1)
+DECL_PUT_END
+
+DECL_FREAD(, SimpleHdrW, 32)
+/* DECL_FWRITE(, SimpleHdrW, 32) */

--- a/src/game/gamedata.h
+++ b/src/game/gamedata.h
@@ -132,6 +132,15 @@ typedef struct {
 #define sizeof_SimpleHdr (2+4)
 extern size_t fread_SimpleHdr(SimpleHdr *dst, size_t num, FILE *f);
 
+/* used in utils/mknews.cpp for TOTNEWS.CDR */
+typedef struct {
+	uint32_t size;
+	uint32_t offset;
+} SimpleHdrW;
+
+#define sizeof_SimpleHdrW (4+4)
+extern size_t fread_SimpleHdrW(SimpleHdrW * dst, size_t num, FILE * f);
+
 #endif /* _GAMEDATA_H */
 
 /** @} */

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(ZLIB REQUIRED)
 find_package(jsoncpp REQUIRED)
 include(FixJsonCppTargets)
 
-add_executable(but2png EXCLUDE_FROM_ALL but2png.c)
+add_executable(but2png EXCLUDE_FROM_ALL but2png.cpp)
 set_target_properties(but2png PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
 #add_dependencies(but2png libs)
 target_link_libraries(but2png PRIVATE PNG::PNG ZLIB::ZLIB)
@@ -17,6 +17,13 @@ add_executable(data_decoder EXCLUDE_FROM_ALL data_decoder.cpp)
 set_target_properties(data_decoder PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
 #add_dependencies(data_decoder libs)
 target_link_libraries(data_decoder PRIVATE JsonCpp::JsonCpp)
+
+add_executable(mkmovie EXCLUDE_FROM_ALL mkmovie.cpp)
+set_target_properties(mkmovie PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+
+add_executable(mknews EXCLUDE_FROM_ALL mknews.cpp)
+set_target_properties(mknews PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)
+target_sources(mknews PRIVATE ${PROJECT_SOURCE_DIR}/src/game/gamedata.cpp)
 
 add_executable(news2png EXCLUDE_FROM_ALL news2png.cpp)
 set_target_properties(news2png PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD 1)

--- a/src/utils/but2png.cpp
+++ b/src/utils/but2png.cpp
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* known strategies:
     utils/but2png ../gamedata/prefs.but "320x240 RLE"
@@ -113,7 +114,7 @@ void PortPal(int player)
 int
 RLED_img(void *src_raw, void *dest_raw, unsigned int src_size, int w, int h)
 {
-    signed char *src = src_raw;
+    signed char *src = (signed char *)src_raw;
     signed char *dest;
     unsigned int used;
     int count, val;
@@ -148,7 +149,7 @@ RLED_img(void *src_raw, void *dest_raw, unsigned int src_size, int w, int h)
         return (w * h);
     }
 
-    dest = dest_raw;
+    dest = (signed char *)dest_raw;
 
     for (row = 0; row < h; row++) {
         memcpy(dest, &buf[row * (w + 1)], w);
@@ -161,8 +162,8 @@ RLED_img(void *src_raw, void *dest_raw, unsigned int src_size, int w, int h)
 int
 PCX_D(void *src_raw, void *dest_raw, unsigned src_size)
 {
-    char *src = src_raw;
-    char *dest = dest_raw;
+    char *src = (char *)src_raw;
+    char *dest = (char *)dest_raw;
     char num;
     char *orig_dest = dest;
 

--- a/src/utils/data_decoder.cpp
+++ b/src/utils/data_decoder.cpp
@@ -1,12 +1,14 @@
 #include <stdint.h>
 
 #include <cassert>
-#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
+
+#include "../game/data.h"
 
 void print_escaped_string(const char *string, int max_length)
 {
@@ -448,8 +450,6 @@ void write_budget_mods(FILE *fp)
         printf("};\n\n");
     }
 }
-
-#include "../game/data.h"
 
 void write_player_data(FILE *fp)
 {

--- a/src/utils/mkmovie.cpp
+++ b/src/utils/mkmovie.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
 #include <string.h>
 
@@ -8,8 +8,8 @@ int vflag;
 int
 RLED(void *src_raw, void *dest_raw, unsigned int src_size)
 {
-    signed char *src = src_raw;
-    signed char *dest = dest_raw;
+    signed char *src = (signed char *)src_raw;
+    signed char *dest = (signed char *)dest_raw;
     unsigned short used;
     short count, val;
     short i;
@@ -51,7 +51,7 @@ RLED(void *src_raw, void *dest_raw, unsigned int src_size)
         }
     }
 
-    return ((void *) dest - dest_raw);
+    return ((char *) dest - (char *)dest_raw);
 }
 
 void
@@ -80,7 +80,7 @@ frm_open(char *filename) {
         return (nullptr);
     }
 
-    if ((frm = calloc(1, sizeof *frm)) == nullptr) {
+    if ((frm = (struct frm *)calloc(1, sizeof *frm)) == nullptr) {
         fprintf(stderr, "out of memory\n");
         exit(EXIT_FAILURE);
     }

--- a/src/utils/mknews.cpp
+++ b/src/utils/mknews.cpp
@@ -1,8 +1,8 @@
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 #include <inttypes.h>
 #include "../game/gamedata.h"
 
@@ -390,8 +390,8 @@ static uint8_t overlay[ovl_w *ovl_h][3] = {
 int
 RLED(void *src_raw, void *dest_raw, unsigned int src_size)
 {
-    signed char *src = src_raw;
-    signed char *dest = dest_raw;
+    signed char *src = (signed char *)src_raw;
+    signed char *dest = (signed char *)dest_raw;
     unsigned short used;
     short count, val;
     short i;
@@ -433,7 +433,7 @@ RLED(void *src_raw, void *dest_raw, unsigned int src_size)
         }
     }
 
-    return ((void *) dest - dest_raw);
+    return ((char *) dest - (char *)dest_raw);
 }
 
 void
@@ -475,7 +475,7 @@ struct news *
 news_open(char *fname) {
     int i = 0;
     SimpleHdrW headers[12];
-    struct news *n = malloc(sizeof *n);
+    struct news *n = (struct news *)malloc(sizeof *n);
 
     if (!n) {
         pexit("malloc");
@@ -522,7 +522,7 @@ news_next_animation(struct news *n, int *x, int *y, int *w, int *h)
     }
 
     nframes = n->animations[idx].frames;
-    n->frames = realloc(n->frames, nframes * sizeof(*n->frames));
+    n->frames = (SimpleHdr *)realloc(n->frames, nframes * sizeof(*n->frames));
 
     if (!n->frames) {
         pexit("realloc");
@@ -612,8 +612,8 @@ news_close(struct news *n)
     assert(n);
 }
 
-char *dirname = ".";
-char *basename = "";
+char *output_dir = ".";
+char *output_basename = "";
 
 void
 write_image(char *data, int width, int height, unsigned char *palette,
@@ -627,7 +627,7 @@ write_image(char *data, int width, int height, unsigned char *palette,
     struct type {
         int is_usa;
         int is_bw;
-        char *shot;
+        const char *shot;
     } sequence[] = {
         { 1, 1, "opening"},
         { 1, 0, "opening"},
@@ -645,8 +645,8 @@ write_image(char *data, int width, int height, unsigned char *palette,
 
     /* who the hell designed these indices?? */
     snprintf(fname, sizeof(fname), "%s/%s%s%s_%s_%s_%02d.ppm",
-             dirname, basename,
-             (basename[0] ? "_" : ""),
+             output_dir, output_basename,
+             (output_basename[0] ? "_" : ""),
              (sequence[anim_no].is_usa ? "usa" : "sov"),
              (sequence[anim_no].is_bw  ? "bw"  : "col"),
              sequence[anim_no].shot, frame_no);
@@ -702,11 +702,11 @@ main(int argc, char **argv)
     while ((c = getopt(argc, argv, "hod:b:")) != EOF) {
         switch (c) {
         case 'd':
-            dirname = optarg;
+            output_dir = optarg;
             break;
 
         case 'b':
-            basename = optarg;
+            output_basename = optarg;
             break;
 
         case 'o':

--- a/src/utils/news2png.cpp
+++ b/src/utils/news2png.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include <png.h>
+#include <string.h>
 #include <zlib.h>
 
 


### PR DESCRIPTION
* Fix building utils and rename them to cpp
Fix building but2png.
Fix building data_decoder.
Fix building mknews.
Fix building news2png.
Rename mkmovie to cpp and add pointer casts.
Rename but2png to cpp and add pointer casts.
Rename mknews to cpp and add pointer casts.

* cmake: Add debug-based build configs with utils
Makes it possible to builds utils all at once.

* ci: Add linux-debug-utils build
Ensures that utils don't silently break anymore.