### PR TITLE
Update GitHub Actions checkout action to v6

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
           # This is useful to avoid https://github.com/microsoft/vcpkg/issues/25349


### PR DESCRIPTION
Github complains about old version using Node20