### PR TITLE
Fix duration and prestige not being awarded

### DIFF
--- a/src/game/prest.cpp
+++ b/src/game/prest.cpp
@@ -796,7 +796,7 @@ int AllotPrest(char plr, char mis)
     }
 
     int mike;
-    if (misType.Dur != 0) {
+    if (misType.Dur == 0) {
         switch (P_Goal) {
         case Prestige_MannedSpaceMission:
             mike = 7;


### PR DESCRIPTION
This was a logic test that got flipped by accident during a code clean-up in 0809950350a47d18d27b6e530011d27321350e3d. I only found this because I hyperfocused on a diff for an hour, and because @peyre nerd-sniped me by saying we couldn't have another release until this bug was fixed. :)

Fixes #1099

Tested by compiling the game locally, and running missions with the `nofail 1` config set. Independent verification appreciated.